### PR TITLE
Fix for ordered lists not showing their numbrered markers in a comment

### DIFF
--- a/OurUmbraco.Site/css/forum.css
+++ b/OurUmbraco.Site/css/forum.css
@@ -66,7 +66,8 @@ padding: 15px; text-align: left; padding-left: 60px }
 
 #forum ul.commentsList li .comment .body{font-size: 12px;}
 #forum ul.commentsList li .comment .body p{font-size: 12px; margin-top: 0px; margin-bottom: 15px;}
-#forum ul.commentsList li .comment .body ul li{  display: list-item; list-style-type: disc; margin-top:.5em; margin-bottom:1em;}
+#forum ul.commentsList li .comment .body li{display: list-item; margin-top:.5em; margin-bottom:1em;}
+#forum ul.commentsList li .comment .body ul li {list-style-type: disc;}
 
 
 /* Solutions */


### PR DESCRIPTION
This fixes the problem with ordered lists not getting their markers, when used inside a comment.
