### PR TITLE
Adds permanent cookie for login (with sliding exp)

### DIFF
--- a/OurUmbraco.Site/web.config
+++ b/OurUmbraco.Site/web.config
@@ -32,7 +32,7 @@
   <ExamineLuceneIndexSets configSource="config\ExamineIndex.config" />
   <FileSystemProviders configSource="config\FileSystemProviders.config" />
   <appSettings>
-    <add key="umbracoDbDSN" value="server=.;database=our.umbraco.org.live;user id=sa;password=abc123" />
+    <add key="umbracoDbDSN" value="server=.\SQL2012;database=our.umbraco.org.live;user id=sa;password=1234" />
     <add key="umbracoConfigurationStatus" value="4.9.1" />
     <add key="umbracoReservedUrls" value="~/config/splashes/booting.aspx,~/install/default.aspx,~/config/splashes/noNodes.aspx,~/Hiccup.aspx,~/signalR,~/VSEnterpriseHelper.axd" />
     <add key="umbracoReservedPaths" value="~/umbraco,~/install/,~/communityLogoGenerator,~/adhoc,~/signalR" />
@@ -199,7 +199,7 @@
       <!-- End of added in Umbraco 4.6.2 -->
     </compilation>
     <authentication mode="Forms">
-      <forms name="yourAuthCookie" loginUrl="login.aspx" protection="All" path="/" />
+      <forms name="yourAuthCookie" loginUrl="login.aspx" protection="All" path="/" slidingExpiration="true" timeout="525600" />
     </authentication>
     <authorization>
       <allow users="?" />


### PR DESCRIPTION
Updates to web.config to make one year sliding expiration to login
time. After the member updates to 4.something the timespan parameter to
the Member cookie method that Our uses is ignored and default
AuthCookie settings from web.config are used instead.
