### PR TITLE
Corrected "wifi.umbraco.org" reference

### DIFF
--- a/OurUmbraco.Site/xslt/forum-topicsList.xslt
+++ b/OurUmbraco.Site/xslt/forum-topicsList.xslt
@@ -43,7 +43,7 @@
       </xsl:variable>
 
       <!-- Register RSS -->
-      <xsl:value-of select="uForum:RegisterRssFeed( concat('http://wifi.umbraco.org/rss/forum?id=',$currentPage/@id), concat('New topics from the ',$currentPage/@nodeName ,' forum'), 'topicRss')"/>
+      <xsl:value-of select="uForum:RegisterRssFeed( concat('http://our.umbraco.org/rss/forum?id=',$currentPage/@id), concat('New topics from the ',$currentPage/@nodeName ,' forum'), 'topicRss')"/>
 
       <xsl:variable name="items">15</xsl:variable>
       <xsl:variable name="pages" select="uForum:ForumPager($currentPage/@id, $items, $p)"/>


### PR DESCRIPTION
Spotted an RSS feed linking to the original preview URL "wifi.umbraco.org". Corrected to "our.umbraco.org".
