### PR TITLE
Update font-size of LI's in Docs to jive better with normal text

### DIFF
--- a/OurUmbraco.Site/css/docs.css
+++ b/OurUmbraco.Site/css/docs.css
@@ -133,7 +133,8 @@
   list-style: decimal;
 }
 #markdown-docs li {
-  line-height: 18px;
+  font-size: 14px;
+  line-height: 22px;
 }
 #markdown-docs ul.unstyled,
 #markdown-docs ol.unstyled {


### PR DESCRIPTION
This updates the `font-size` of `<li>` tags in the Documentation section, which are currently smaller than the normal text.

**Old:**

![](http://f.cl.ly/items/453z0j1z3D3U0m3f1202/SNAG_Program-0044.png)

**New:**

![](http://f.cl.ly/items/141U2Y021g160S333H0k/SNAG_Program-0043.png)
