### PR TITLE
Default site search to search all areas of the site...

### DIFF
--- a/our.umbraco.org/usercontrols/ExamineSearchResults.ascx.cs
+++ b/our.umbraco.org/usercontrols/ExamineSearchResults.ascx.cs
@@ -278,8 +278,8 @@ namespace our.usercontrols
             // set the searchterm back for the results view
             searchTerm = orgSearchTerm;
 
-            //Get where to search (content)
-            string searchWhere = Request.QueryString["content"];
+            //Get where to search (content) - default to all areas (because Chrome default search doesn't provide content parameter, only q)
+            string searchWhere = !string.IsNullOrEmpty(Request.QueryString["content"]) ? Request.QueryString["content"] : "wiki,forum,project,documentation,";
 
             searchResults = FilterOnContentType(searchWhere, searchResults);
 


### PR DESCRIPTION
... , because Google site search doesn't provide a content parameter in the URL.

One thing I noticed was that in uRelease/ApiController.cs I had to comment out lines 75-91 to get the project to build. I haven't checked in that change, but it might be worth someone having a look at it? "umbraco.Nodefactory.Node does not contain a definition for 'GetPropertyValue'..."
