### PR TITLE
Updates for Pagination on Member Notifications

### DIFF
--- a/OurUmbraco.Site/css/community.css
+++ b/OurUmbraco.Site/css/community.css
@@ -326,6 +326,8 @@ color: #514721; display: block; text-align: center;  margin-bottom: 7px;}
 .pager li a:hover{color: white; background: #252525; border-color: #252525}
 .pager li.current a{font-weight: bold;}
 .MemberTopicNotifications .pager li.current {font-weight: bold; padding: 1px 6px; font-size: 12px;}
+.MemberTopicNotifications .pager li.all a { margin-left: 10px; border: 2px solid #900; }
+.MemberTopicNotifications .pager li.all a:hover { border-color: #252525; }
 
 .MemberTopicNotifications li.TopicSolved a { color: #77a948; text-decoration: none; }
 .MemberTopicNotifications li.TopicSolved a:hover { color: #77a948; text-decoration: underline; }

--- a/OurUmbraco.Site/css/community.css
+++ b/OurUmbraco.Site/css/community.css
@@ -327,6 +327,9 @@ color: #514721; display: block; text-align: center;  margin-bottom: 7px;}
 .pager li.current a{font-weight: bold;}
 .MemberTopicNotifications .pager li.current {font-weight: bold; padding: 1px 6px; font-size: 12px;}
 
+.MemberTopicNotifications li.TopicSolved a { color: #77a948; text-decoration: none; }
+.MemberTopicNotifications li.TopicSolved a:hover { color: #77a948; text-decoration: underline; }
+
 #memberLoader span, #memberLoader_weeks span, #memberLoader_year span{display: block; background: url(img/ajax-loadercircle.gif) no-repeat center left; 
     font-size: 11px; color: #999; margin: 10px; padding: 5px 30px 10px 40px; width: 200px;}
 

--- a/OurUmbraco.Site/xslt/_PaginationHelper.xslt
+++ b/OurUmbraco.Site/xslt/_PaginationHelper.xslt
@@ -242,7 +242,14 @@
 						<a href="{$query}{$sep}{$pagerParam}={$page + 1}" rel="next"><xsl:value-of select="$nextPage"/></a>
 					</xsl:otherwise>
 				</xsl:choose>
-			</li>			
+			</li>
+			
+			<!-- Create the "All" link -->
+			<li class="all">
+				<a href="{$query}{$sep}{$pagerParam}=all">
+					<xsl:value-of select="concat('Show all ', $total, ' topics')" />
+				</a>
+			</li>
 		</ul>
 	</xsl:template>
 	

--- a/OurUmbraco.Site/xslt/member-notifications.xslt
+++ b/OurUmbraco.Site/xslt/member-notifications.xslt
@@ -55,6 +55,12 @@
 					<xsl:when test="not($topicsubscriptions//topic)">
 						<p>Currently no active subscriptions.</p>
 					</xsl:when>
+					<!-- Show absolutely everything if the pagerParam is "all" (e.g.: p=all) -->
+					<xsl:when test="translate($options[@key = $pagerParam], 'AL', 'al') = 'all'">
+						<xsl:apply-templates select="$topicsubscriptions//topic">
+							<xsl:sort select="@updated" data-type="text" order="descending" />
+						</xsl:apply-templates>
+					</xsl:when>
 					<xsl:otherwise>
 						<ul class="MemberTopicNotifications">
 							<xsl:call-template name="PaginateSelection">

--- a/OurUmbraco.Site/xslt/member-notifications.xslt
+++ b/OurUmbraco.Site/xslt/member-notifications.xslt
@@ -18,16 +18,13 @@
 	<xsl:output method="xml" omit-xml-declaration="yes"/>
 
 	<xsl:param name="currentPage"/>
-
-	<xsl:variable name="mem">
-		<xsl:if test="umbraco.library:IsLoggedOn()">
-			<xsl:value-of select="umbraco.library:GetCurrentMember()/@id"/>
-		</xsl:if>
-	</xsl:variable>
+	
+	<xsl:variable name="isLoggedOn" select="umbraco.library:IsLoggedOn()" />
+	<xsl:variable name="member" select="umbraco.library:GetCurrentMember()" />
 
 	<xsl:template match="/">
 		<xsl:choose>
-			<xsl:when test="umbraco.library:GetCurrentMember()/bugMeNot = 1">
+			<xsl:when test="$isLoggedOn and $member[bugMeNot = 1]">
 				<div class="alert" style="width:600px">
 					Currently you will not receive any notifications since your profile preference is set
 					to 'Do not send me any notifications or newsletters from our.umbraco.org'.
@@ -38,7 +35,7 @@
 				<h2>Forum subscriptions</h2>
 				<small>You get notified whenever a new topic is added to the subscribed forums.</small>
 				
-				<xsl:variable name="forumsubscriptions" select="Notifications:SubscribedForums($mem)" />
+				<xsl:variable name="forumsubscriptions" select="Notifications:SubscribedForums($member/@id)" />
 				<xsl:choose>
 					<xsl:when test="not($forumsubscriptions//forum)">
 						<p>Currently no active subscriptions.</p>
@@ -53,7 +50,7 @@
 				<h2>Topic subscriptions</h2>
 				<small>You get notified whenever a new reply is added to the subscribed topics.</small>
 
-				<xsl:variable name="topicsubscriptions" select="Notifications:SubscribedTopics($mem)" />
+				<xsl:variable name="topicsubscriptions" select="Notifications:SubscribedTopics($member/@id)" />
 				<xsl:choose>
 					<xsl:when test="not($topicsubscriptions//topic)">
 						<p>Currently no active subscriptions.</p>

--- a/OurUmbraco.Site/xslt/member-notifications.xslt
+++ b/OurUmbraco.Site/xslt/member-notifications.xslt
@@ -60,6 +60,7 @@
 							<xsl:call-template name="PaginateSelection">
 								<xsl:with-param name="selection" select="$topicsubscriptions//topic" />
 								<xsl:with-param name="perPage" select="50" />
+								<xsl:with-param name="sortBy" select="'@updated DESC'" />
 							</xsl:call-template>
 						</ul>
 					</xsl:otherwise>

--- a/OurUmbraco.Site/xslt/member-notifications.xslt
+++ b/OurUmbraco.Site/xslt/member-notifications.xslt
@@ -82,6 +82,7 @@
 	
 	<xsl:template match="topic">
 		<li>
+			<xsl:if test="not(@answer = 0)"><xsl:attribute name="class">TopicSolved</xsl:attribute></xsl:if>
 			<a href="{uForum:NiceTopicUrl(@id)}">
 				<xsl:value-of select="title" />
 			</a>

--- a/OurUmbraco.Site/xslt/member-notifications.xslt
+++ b/OurUmbraco.Site/xslt/member-notifications.xslt
@@ -50,21 +50,21 @@
 				<h2>Topic subscriptions</h2>
 				<small>You get notified whenever a new reply is added to the subscribed topics.</small>
 
-				<xsl:variable name="topicsubscriptions" select="Notifications:SubscribedTopics($member/@id)" />
+				<xsl:variable name="topicsubscriptions" select="Notifications:SubscribedTopics($member/@id)//topic" />
 				<xsl:choose>
-					<xsl:when test="not($topicsubscriptions//topic)">
+					<xsl:when test="not($topicsubscriptions)">
 						<p>Currently no active subscriptions.</p>
 					</xsl:when>
 					<!-- Show absolutely everything if the pagerParam is "all" (e.g.: p=all) -->
 					<xsl:when test="translate($options[@key = $pagerParam], 'AL', 'al') = 'all'">
-						<xsl:apply-templates select="$topicsubscriptions//topic">
+						<xsl:apply-templates select="$topicsubscriptions">
 							<xsl:sort select="@updated" data-type="text" order="descending" />
 						</xsl:apply-templates>
 					</xsl:when>
 					<xsl:otherwise>
 						<ul class="MemberTopicNotifications">
 							<xsl:call-template name="PaginateSelection">
-								<xsl:with-param name="selection" select="$topicsubscriptions//topic" />
+								<xsl:with-param name="selection" select="$topicsubscriptions" />
 								<xsl:with-param name="perPage" select="50" />
 								<xsl:with-param name="sortBy" select="'@updated DESC'" />
 							</xsl:call-template>


### PR DESCRIPTION
This is a pull-request for the functionality described in a [comment](https://github.com/umbraco/OurUmbraco/pull/31#issuecomment-56880594) on #31 

* Add a **Show all #### topics!** button to the pager
* Add class `TopicSolved` to solved topics (with styles)
* Sorting the results by **updated** (descending)

Should make @jbreuer and others happy :)

Reference renderings:

![c10b32a6-44f3-11e4-8607-ae074b38e06c](https://cloud.githubusercontent.com/assets/5463/5497328/d5c2de56-8710-11e4-9917-a0f82abbf3f2.png)

![c92712de-44f3-11e4-9191-51f135156e97](https://cloud.githubusercontent.com/assets/5463/5497342/f04398a6-8710-11e4-962b-b3db559a60a2.png)

