### PR TITLE
OUR-148 Project releases - displayed owner's name, instead of uploader.

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -184,6 +184,7 @@
 
                                 @foreach (var release in source.Where(x => !x.Archived).OrderByDescending(x => x.Version.Version))
                                 {
+                                    var uploader = Members.GetById(release.CreatedBy) ?? owner;
                                     <li>
                                         <a href="/FileDownload?id=@release.Id">
                                             <div class="type-icon">
@@ -195,7 +196,7 @@
                                                     @release.Name
                                                 </div>
                                                 <div class="type-description">
-                                                    uploaded @release.CreateDate.ToShortDateString() by @owner.Name<br>
+                                                    uploaded @release.CreateDate.ToShortDateString() by @uploader.Name<br>
                                                 </div>
                                             </div>
                                         </a>


### PR DESCRIPTION
Corrected the package uploader's name.