### PR TITLE
Fix: OUR-304

### DIFF
--- a/OurUmbraco.Client/src/scss/pages/_release.scss
+++ b/OurUmbraco.Client/src/scss/pages/_release.scss
@@ -218,7 +218,7 @@
 
 		a {
 			text-decoration: none;
-
+			font-family: $font-family;
 
 			&:hover {
 				text-decoration: underline;


### PR DESCRIPTION
Added font-family property to .markdown-syntax anchor tags