### PR TITLE
OUR-318: Fix text when only on vote for a package

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -52,13 +52,46 @@
 
         <div class="vote">
             <i class="icon-Hearts @(hasMemberVoted ? "liked" : null)"></i>
-            @if (Members.IsLoggedIn() == false || currentMember.Id == owner.Id || hasMemberVoted)
+            
+            @if (Members.IsLoggedIn() == false || currentMember.Id == owner.Id)
             {
-                <span>@totalVotes votes</span>
+
+                if (totalVotes == 0 || totalVotes > 1)
+                {
+                    <span>@totalVotes votes</span>
+                }
+                else
+                {
+                    <span>@totalVotes vote</span>
+                }
+
+
             }
-            else
+
+           @if (Members.IsLoggedIn() && hasMemberVoted)
+           {
+               if (totalVotes == 0 || totalVotes > 1)
+               {
+                <span>@totalVotes votes</span>
+               }
+               else
+               {
+                <span>@totalVotes vote</span>
+               }
+           }
+
+            @if (Members.IsLoggedIn() && !hasMemberVoted)
             {
-                <a href="#" id="projectVote" data-id="@project.Id">@totalVotes votes</a>
+                if (totalVotes == 0 || totalVotes > 1)
+                {
+                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes votes</a>
+                }
+                else
+                {
+                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes vote</a>
+                }
+
+
             }
         </div>
 

--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -59,43 +59,17 @@
             
             @if (Members.IsLoggedIn() == false || currentMember.Id == owner.Id)
             {
-
-                if (totalVotes == 0 || totalVotes > 1)
-                {
-                    <span>@totalVotes @voteText</span>
-                }
-                else
-                {
-                    <span>@totalVotes @voteText</span>
-                }
-
-
+                <span>@totalVotes @voteText</span>    
             }
 
            @if (Members.IsLoggedIn() && hasMemberVoted)
            {
-               if (totalVotes == 0 || totalVotes > 1)
-               {
                 <span>@totalVotes @voteText</span>
-               }
-               else
-               {
-                <span>@totalVotes vote</span>
-               }
            }
 
             @if (Members.IsLoggedIn() && !hasMemberVoted)
-            {
-                if (totalVotes == 0 || totalVotes > 1)
-                {
-                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes @voteText</a>
-                }
-                else
-                {
-                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes @voteText</a>
-                }
-
-
+            {               
+                <a href="#" id="projectVote" data-id="@project.Id">@totalVotes @voteText</a>
             }
         </div>
 

--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -42,6 +42,10 @@
     var demoUrl = project.GetPropertyValue<string>("demoUrl");
     var licenseUrl = project.GetPropertyValue<string>("licenseUrl");
     var supportUrl = project.GetPropertyValue<string>("supportUrl");
+
+    var voteText = "votes";
+    if (totalVotes == 1) { voteText = "vote"; } 
+
 }
 
 <section class="package-detail">
@@ -58,11 +62,11 @@
 
                 if (totalVotes == 0 || totalVotes > 1)
                 {
-                    <span>@totalVotes votes</span>
+                    <span>@totalVotes @voteText</span>
                 }
                 else
                 {
-                    <span>@totalVotes vote</span>
+                    <span>@totalVotes @voteText</span>
                 }
 
 
@@ -72,7 +76,7 @@
            {
                if (totalVotes == 0 || totalVotes > 1)
                {
-                <span>@totalVotes votes</span>
+                <span>@totalVotes @voteText</span>
                }
                else
                {
@@ -84,11 +88,11 @@
             {
                 if (totalVotes == 0 || totalVotes > 1)
                 {
-                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes votes</a>
+                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes @voteText</a>
                 }
                 else
                 {
-                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes vote</a>
+                    <a href="#" id="projectVote" data-id="@project.Id">@totalVotes @voteText</a>
                 }
 
 


### PR DESCRIPTION
When a package only has 1 vote the text should be "1 vote" instead of "1 votes".

Some examples:
https://our.umbraco.org/projects/collaboration/mdedit/
https://our.umbraco.org/projects/backoffice-extensions/nupickers-vimeo-picker/
https://our.umbraco.org/projects/backoffice-extensions/attackmonkey-grid-locker/