### PR TITLE
OUR-322: Removed the is Stable information, you can´t add it on the c…

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -321,10 +321,6 @@
                 <li>
                     <span>Created:</span> @project.CreateDate.ToShortDateString()
                 </li>
-
-                <li>
-                    <span>Is Stable:</span> @project.GetPropertyValue("stable")
-                </li>
                 <li>
                     <span>Current version</span> @project.GetPropertyValue("version")
                 </li>


### PR DESCRIPTION
If you go to a specific package page (for example: https://our.umbraco.org/projects/backoffice-extensions/perplexmail-for-umbraco/) you see on the rightside "Is stable: False". There used to be a checkbox for that option in the edit-screen of a package but that disappeared.

I think the line that displays this should be removed completely (, or there has to be a checkbox on the edit-page)
