### PR TITLE
Correctly pluralize "votes", using a helper

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -54,11 +54,11 @@
             <i class="icon-Hearts @(hasMemberVoted ? "liked" : null)"></i>
             @if (Members.IsLoggedIn() == false || currentMember.Id == owner.Id || hasMemberVoted)
             {
-                <span>@totalVotes votes</span>
+                <span>@pluralize(totalVotes, "vote", "votes")</span>
             }
             else
             {
-                <a href="#" id="projectVote" data-id="@project.Id">@totalVotes votes</a>
+                <a href="#" id="projectVote" data-id="@project.Id">@pluralize(totalVotes, "vote", "votes")</a>
             }
         </div>
 
@@ -423,4 +423,13 @@
         ga('create', '@(Model.Content.GetPropertyValue("gaCode"))', 'auto', { 'name': 'PackageMaker' });
         ga('PackageMaker.send', 'pageview');
     </script>
+}
+
+@helper pluralize(int count, string oneValue, string pluralValue)
+{
+	if (count == 1) {
+		<text>@count @oneValue</text>
+	} else {
+		<text>@count @pluralValue</text>
+	}
 }


### PR DESCRIPTION
This is a quick fix for OUR-318, using a `pluralize()` helper. Not sure if there's a "general" place to put said helper - let me know if it's preferred to be in a specific file.