### PR TITLE
OUR-276 - Colorize Project Compatibility

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_package-detail.scss
+++ b/OurUmbraco.Client/src/scss/elements/_package-detail.scss
@@ -231,6 +231,15 @@
 		display: block;
 		font-weight: normal;
 	}
+
+	.smiley {
+		&.untested { color: #ccc; }
+		&.unhappy, &.superUnhappy { color: #f55b6d; }
+		&.neutral { color: rgba(0, 0, 0, 0.6); }
+		&.happy, &.joyous { color: #2ba92d; }
+		&.joyous { font-weight: bold; }
+	}
+
 	
 	.report-compat-item {
 		float: right;


### PR DESCRIPTION
Add styles for the `.smiley` states that were actual icons in the old site, e.g.:

- **untested**
- **superUnhappy**
- **unhappy**
- **neutral**
- **happy**
- **joyous**

Decided against the checkmark on *joyous* (as depicted in the [initial mockup][1]), after testing some scenarios of various combinations of states. They were a bit noisy :)

A **100%** compatible version gets bold-faced which seems to do the job.

[1]: http://issues.umbraco.org/issue/OUR-276?replyTo=67-22325#viewimage=project-compatibility-with-colors.png%3Ffile%3D64-2837%26v%3D0%26c%3Dtrue%26rw%3D918%26rh%3D724%26u%3D1435702794207