### PR TITLE
OUR-341 Fixed cutting fotter on smartphone 

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_footer.scss
+++ b/OurUmbraco.Client/src/scss/elements/_footer.scss
@@ -23,7 +23,7 @@ footer {
 	font-size: .9rem;
 	text-align: center;
 	line-height: 1.5;
-
+    height:100%;
 	width: 100%;
 }
 


### PR DESCRIPTION
The text in the footer are being cut off on mobiles iPhone 4, 5 and 6

http://issues.umbraco.org/issue/OUR-341