### PR TITLE
OUR-345 Fix for version label so it always align right

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_packages.scss
+++ b/OurUmbraco.Client/src/scss/elements/_packages.scss
@@ -67,6 +67,10 @@ body.packages {
 		border-bottom: 1px solid whitesmoke;
 		width: 100%;
 
+        .row{ 
+            width:100%;
+        }
+
 		h3 {
 			font-size: 1.1rem;
 			margin-bottom: .5rem;


### PR DESCRIPTION
For some packages in the package list (here seen for popular projects) the version label are not all right aligned in same way.

http://issues.umbraco.org/issue/OUR-345