### PR TITLE
Ensure GitHub URLs are always in correct case.

### DIFF
--- a/OurUmbraco/Documentation/DocumentationContentFinder.cs
+++ b/OurUmbraco/Documentation/DocumentationContentFinder.cs
@@ -5,6 +5,7 @@ using System.Web;
 using OurUmbraco.Documentation.Busineslogic;
 using Umbraco.Core;
 using Umbraco.Web.Routing;
+using System.Text.RegularExpressions;
 
 namespace OurUmbraco.Documentation
 {
@@ -154,6 +155,15 @@ namespace OurUmbraco.Documentation
 
                 //Ensure beginning part of url is right case for GitHub URL
                 originalUrl = originalUrl.Replace("/documentation/", "/");
+
+                //Ensure parts of URL (after forward slash) begin with uppercase to match GitHub URLs.
+                string expression = @"[\/]([a-z])";
+                char[] charArray = originalUrl.ToCharArray();
+                foreach (Match match in Regex.Matches(originalUrl, expression, RegexOptions.Singleline))
+                {
+                    charArray[match.Groups[1].Index] = Char.ToUpper(charArray[match.Groups[1].Index]);
+                }
+                originalUrl = new string(charArray);
 
                 //If ends with / then it's an index.md file in a folder
                 if (originalUrl.EndsWith("/"))


### PR DESCRIPTION
This is to resolve [Issue #271](https://github.com/umbraco/UmbracoDocs/issues/271) within the UmbracoDocs repo. Issue being users navigating the documentation site with lowercase URLs were throwing 404's when hitting GitHub which is case sensitive.

First contribution to Umbraco, so apologies in advanced if my processes aren't correct!
