### PR TITLE
OUR-387 Solved "green color" not showing on startpage of Our

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Forum/LatestActivity.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Forum/LatestActivity.cshtml
@@ -19,7 +19,7 @@
         var cat = Umbraco.TypedContent(topic.ParentId);
         var mem = Members.GetById(topic.LatestReplyAuthor) ?? Members.GetById(topic.MemberId);
 
-        <a href="@topic.GetUrl()" class="forum-thread">
+        <a href="@topic.GetUrl()" class="forum-thread @Umbraco.If(topic.Answer > 0, " solved")">
 
             <div class="avatar">
 				@if(mem != null)


### PR DESCRIPTION
http://issues.umbraco.org/issue/OUR-387

Added the "solved" class on the latestactivity forum-threads.

For some reasons, i did´nt get the /assets/css/style.min.css when i
cloned the repository, and i could´nt find it in
https://github.com/umbraco/OurUmbraco/tree/master/OurUmbraco.Site
either.

This css needs to be added to style.min.css for the threads to be green:

.forum .forum-thread.solved {
background: rgba(163, 219, 120, 0.23) none repeat scroll 0 0;
border: 2px solid rgba(163, 219, 120, 0.66);
}