### PR TITLE
Extracts package's required Umbraco version metadata

### DIFF
--- a/OurUmbraco.Site/usercontrols/Deli/Package/Steps/Files.ascx
+++ b/OurUmbraco.Site/usercontrols/Deli/Package/Steps/Files.ascx
@@ -192,9 +192,10 @@
                 
          
             </p>
-            <div class="pickVersion">
+            <div class="pickVersion" style="float:left;margin-bottom:10px;">
                 <asp:literal ID="lt_versions" runat="server" />
                 </div>
+            <p style="clear:both;margin-bottom:10px;">If your package manifest references a specific version of Umbraco, then that will be used instead.</p>
         </div>
         <p id="pickNetVersion">
               <label class="inputLabel">Choose supported .NET runtime</label>

--- a/OurUmbraco/Project/usercontrols/Deli/Package/Steps/Files.ascx
+++ b/OurUmbraco/Project/usercontrols/Deli/Package/Steps/Files.ascx
@@ -192,9 +192,10 @@
                 
          
             </p>
-            <div class="pickVersion">
+            <div class="pickVersion" style="float:left;margin-bottom:10px;">
                 <asp:literal ID="lt_versions" runat="server" />
                 </div>
+            <p style="clear:both;margin-bottom:10px;">If your package manifest references a specific version of Umbraco, then that will be used instead.</p>
         </div>
         <p id="pickNetVersion">
               <label class="inputLabel">Choose supported .NET runtime</label>


### PR DESCRIPTION
When a package is uploaded to the Our Umbraco repository, we extract the "package.xml" manifest to detect the required (minimum) Umbraco version number.

This task is part of [U4-8156](http://issues.umbraco.org/issue/U4-8156), at CGRT16