### PR TITLE
OUR-404 Update release pages to have a far more prominent call to action for download and install instructions

### DIFF
--- a/OurUmbraco.Client/gulpfile.js
+++ b/OurUmbraco.Client/gulpfile.js
@@ -1,4 +1,4 @@
-var gulp         = require('gulp'), 
+var gulp         = require('gulp'),
     gutil        = require('gulp-util'),
     sass         = require('gulp-sass'),
     jshint       = require('gulp-jshint'),
@@ -57,7 +57,7 @@ gulp.task('css', function () {
         .pipe(sass())
 		.on('error', gutil.log)
 		.pipe(autoprefixer('last 1 version', 'ie 9', 'ios 7'))
-		.pipe(cmq({log: true}))
+		// .pipe(cmq({log: true}))
 		.pipe(rename({suffix: '.min'}))
 		.pipe(minifyCss())
         .pipe(gulp.dest(settings.build + '/assets/css'))

--- a/OurUmbraco.Client/package.json
+++ b/OurUmbraco.Client/package.json
@@ -7,17 +7,16 @@
   "dependencies": {
   },
   "devDependencies": {
-    "gulp": "3.8.x",
-    "gulp-util": "2.2.x",
+    "gulp": "^3.9.1",
+    "gulp-util": "3.0.x",
     "gulp-watch": "0.6.x",
     "gulp-minify-css": "1.1.x",
-    "node-sass": "3.2.x",
-    "gulp-sass": "2.0.x",
-    "gulp-combine-media-queries": "0.1.x",
+    "gulp-sass": "^2.2.0",
+    "gulp-combine-media-queries": "0.2.x",
     "gulp-imagemin": "0.6.x",
-    "gulp-autoprefixer": "2.3.1",
-    "gulp-uglify": "0.3.x",
-    "gulp-jshint": "1.6.x",
+    "gulp-autoprefixer": "^3.1.0",
+    "gulp-uglify": "^1.5.3",
+    "gulp-jshint": "2.0.0",
     "gulp-concat": "2.2.x",
     "jshint-stylish": "0.2.x",
     "gulp-clean": "0.3.x",
@@ -28,9 +27,5 @@
     "test": "gulp build --verbose"
   },
   "author": "umbraco",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/devdk/gulp-workflow.git"
-  }
+  "license": "MIT"
 }

--- a/OurUmbraco.Client/src/scss/elements/_alertbar.scss
+++ b/OurUmbraco.Client/src/scss/elements/_alertbar.scss
@@ -4,6 +4,7 @@
 	border: none !important;
 
 	padding: 20px;
+	line-height: 1.5;
 
 	@include colorset(alertbar);
 

--- a/OurUmbraco.Client/src/scss/elements/_buttons.scss
+++ b/OurUmbraco.Client/src/scss/elements/_buttons.scss
@@ -1,7 +1,11 @@
 button.button, .button, a.button {
 	background: $color-blue;
-	padding: 14px 40px;
-	display: inline-block;
+	padding: 0 40px;
+	height: 44px;
+
+	display: inline-flex;
+	align-items: center;
+
 	text-decoration: none;
 	border: none;
 	border-radius: 36px;
@@ -11,8 +15,7 @@ button.button, .button, a.button {
 
 	color: #fff;
 	text-align: center;
-	font-size: 1rem;
-	line-height: 1;
+	font-size: 14px;
 
 	margin: 0;
 
@@ -103,7 +106,7 @@ button.button, .button, a.button {
 
 
 	&.large {
-		font-size: 1.2rem;
+		font-size: 1.175rem;
 	}
 
 

--- a/OurUmbraco.Client/src/scss/pages/_release.scss
+++ b/OurUmbraco.Client/src/scss/pages/_release.scss
@@ -1,39 +1,29 @@
-.download {
+.download.latest .dot {
+	margin-top: 2rem;
+}
 
-
-	.dot.progress {
+.download .dot.progress {
 	text-indent: .3rem;
 	text-align: center;
 	line-height: 2.8rem;
-
-
-		.counter {
-			font-size: 1.1rem;;
-		}
-	}
-
-
-	&.latest {
-
-
-		.dot {
-			margin-top: 2rem;
-		}
-	}
 }
 
+.download .dot.progress .counter {
+	font-size: 1.1rem;
+}
 
 
 .explain {
+	flex-direction: column;
 
-
-	.changes {
-		small {
-			line-height: .5rem;
-		}
+	@media (min-width: 768px) {
+		flex-direction: row;
 	}
 }
 
+.explain .changes small {
+	line-height: .5rem;
+}
 
 
 .chart {
@@ -41,119 +31,111 @@
 	top: -4px;
 	left: -8px;
 	z-index: 1;
-
-
-	.percentage {
-		display: inline-block;
-		position: absolute;
-		top: 9px;
-		left: 16px;
-		font-size: 1.1rem;
-        color: darken($color-our, 30%);
-	}
-
-
-	canvas {
-		top: 1px;
-		position: absolute;
-		left: 5px;
-	}
-
 }
 
+.chart .percentage {
+	display: inline-block;
+	position: absolute;
+	top: 9px;
+	left: 16px;
+	font-size: 1.1rem;
+	color: darken($color-our, 30%);
+}
 
+.chart canvas {
+	top: 1px;
+	position: absolute;
+	left: 5px;
+}
 
-.get-release {
-
-
-	i {
-		font-size: 2.5rem;
-		line-height: 5rem;
-	}
+.chart {
+	position: absolute;
+	top: -4px;
+	left: -8px;
+	z-index: 1;
 }
 
 
 
 .get-release {
 	line-height: 1.5;
-	padding: 2.5rem 0;
-	margin: 2.5rem 0;
+	padding: 2rem 0;
+	margin: 0 0 2.5rem ;
 	border-bottom: 1px solid darken(whitesmoke, 5%);
-	border-top: 1px solid darken(whitesmoke, 5%);
+}
 
+.get-release i {
+	font-size: 2.5rem;
+	line-height: 5rem;
+}
 
-	h3 {
-		font-size: 1.1rem;
-		margin-bottom: .3rem;
-		color: $color-headline;
+.get-release h3 {
+	font-size: 1.1rem;
+	margin-bottom: .3rem;
+	color: $color-headline;
+}
 
+.get-release h3 a {
+	text-decoration: none;
 
-		a {
-			text-decoration: none;
-
-
-			&:hover {
-				color: $color-our;
-			}
-		}
-	}
-
-
-	p {
-		color: $color-headline;
-		font-size: .95rem;
-		line-height: 1.3;
-		margin-bottom: .5rem;
-	}
-
-
-	small {
-		font-size: .7rem;
-		color: $color-text;
+	&:hover {
+		color: $color-our;
 	}
 }
 
+.get-release p {
+	color: $color-headline;
+	font-size: .95rem;
+	line-height: 1.3;
+	margin-bottom: .5rem;
+}
+
+
+.get-release small {
+	font-size: .8rem;
+	color: rgba($color-text, .6);
+}
 
 
 .release {
 	min-height: 160px;
-	
+
 
 	&.zip {
-	
+
 
 		i {
 			color: $color-headline;
 		}
 	}
 
-	
+
 	&.bin {
-	
+
 
 		i {
 			color: rgba(#000, .4);
 			font-size: 1.6rem;
 		}
 
-	
+
 		h4 {
 			font-size: .9rem;
 			margin-bottom: .3rem;
 			color: $color-headline;
 
-	
+
 			a {
 				text-decoration: none;
 
-	
+
 				&:hover {
 					color: $color-our;
 				}
 			}
 		}
-	
-	
+
+
 		&.col-sm-5 {
 			padding-top: 18px;
 		}
@@ -177,7 +159,7 @@
 
 
 	.explain {
-		
+
 
 		h4 {
 			font-size: 2.5rem;
@@ -199,11 +181,9 @@
 
 
 // Single release page
-.release{
-
+.release {
 
 	.markdown-syntax {
-
 
 		p, li, ul, a {
 			color: $color-headline;
@@ -216,7 +196,7 @@
 		}
 
 
-		a {		
+		a {
 			text-decoration: underline;
 			font-family: $font-family;
 		}
@@ -253,11 +233,11 @@
 		}
 	}
 }
+
+
 .releaseTable {
 
-
 	.col-xs-3 {
-
 
 		&:first-child {
 			.progress {
@@ -281,6 +261,7 @@
 		}
 	}
 }
+
 
 // Progress page
 .inprogress {
@@ -324,11 +305,12 @@
 	}
 }
 
+
 // Roadmap page
 .plannedreleases {
 	.dot.big {
 		text-indent: 0;
-		line-height: 3rem;	
+		line-height: 3rem;
 	}
 	.chart {
 		top: 0px;
@@ -341,4 +323,193 @@
 			position: initial;
 		}
 	}
+}
+
+
+.release-page .explain h2 {
+	margin: 0;
+	font-size: 2em;
+	color: rgba(0,0,0,.8);
+}
+
+.release-page .explain small {
+	margin-bottom: 0;
+}
+
+.release-page .dot {
+	border: none;
+}
+
+.release-page .dot.big {
+	position: relative;
+	text-indent: 0;
+	margin: 0;
+}
+
+.release-page .chart {
+	height: 60px;
+	width: 60px;
+	top: initial;
+	left: initial;
+	text-align: center;
+}
+
+.release-page .chart p {
+	vertical-align: middle;
+	line-height: 3.7rem;
+	display: inline-block;
+}
+
+.release-page .chart canvas {
+	top: 0px;
+	left: 0px;
+}
+
+.statuses ul {
+	list-style-type: none;
+}
+.statuses ul li  {
+	position: relative;
+	margin-bottom: 10px;
+	padding-left: 10px;
+}
+.statuses li:before {
+	position: absolute;
+	top: -4px;
+	left: -25px;
+	font-size: 1.5em;
+}
+
+
+
+
+.release-progress-indicator {
+	flex: 1 1 auto;
+}
+
+.release-progress-action {
+	flex: 1 1 auto;
+
+	margin-top: 30px;
+}
+
+.release-progress-version {
+	margin-left: 15px;
+}
+
+
+
+.release-header {
+	flex: 0 0 100%;
+	padding-bottom: 5px;
+	margin-bottom: 2.5rem;
+
+	border-bottom: 1px solid darken(whitesmoke, 5%);
+}
+
+.release-header h2 {
+	font-size: 1.6rem;
+	font-weight: 700;
+}
+
+
+
+.release-section-group {
+	flex: 1 1 100%;
+	padding: 0;
+
+	@media (min-width: 768px) {
+		flex: 1 1 47%;
+	    padding: 0 3% 0 0;
+	}
+}
+
+.release-section-group:nth-child(even) {
+	flex: 1 1 100%;
+	padding: 0;
+
+	@media (min-width: 768px) {
+		flex: 1 1 47%;
+	    padding: 0 0 0 3%;
+	}
+}
+
+.release-section-action {
+	height: 80px;
+
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+
+	box-sizing: border-box;
+}
+
+.release-other-files .release {
+	min-height: auto;
+	margin-bottom: 30px;
+}
+
+.release-other-files .release a {
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-top: 10px;
+}
+
+.release-other-files .release p {
+	margin-top: 0;
+}
+
+
+.release-section code {
+	overflow: auto;
+
+	background-color: #333;
+	background-clip: padding-box;
+
+	color: #fff;
+	font-size: 12px;
+	line-height: 1.4em;
+	text-align: center;
+	text-decoration: none;
+
+
+	padding: 8px 10px 8px 10px;
+
+	width: auto;
+	border-radius: 5px;
+    border: none;
+}
+
+
+.release-section + .release-section {
+	margin-top: 30px;
+}
+
+.release-section-group + .release-section-group {
+	margin-top: 30px;
+
+	@media (min-width: 768px) {
+		margin-top: 0;
+	}
+}
+
+.release-section h3 {
+	font-size: 1.1rem;
+	font-weight: bold;
+	margin-bottom: 0;
+}
+
+
+.release-other-files {
+	margin-top: 3rem;
+}
+
+.release-other-files h3 {
+	font-size: 1.1rem;
+	margin-bottom: 5px;
+}
+
+.release-other-files small {
+	font-size: .8rem;
+	color: rgba($color-text, .5);
 }

--- a/OurUmbraco.Client/src/scss/pages/_release.scss
+++ b/OurUmbraco.Client/src/scss/pages/_release.scss
@@ -13,6 +13,7 @@
 }
 
 
+
 .explain {
 	flex-direction: column;
 
@@ -24,6 +25,7 @@
 .explain .changes small {
 	line-height: .5rem;
 }
+
 
 
 .chart {
@@ -97,86 +99,25 @@
 }
 
 
-.release {
-	min-height: 160px;
-
-
-	&.zip {
-
-
-		i {
-			color: $color-headline;
-		}
-	}
-
-
-	&.bin {
-
-
-		i {
-			color: rgba(#000, .4);
-			font-size: 1.6rem;
-		}
-
-
-		h4 {
-			font-size: .9rem;
-			margin-bottom: .3rem;
-			color: $color-headline;
-
-
-			a {
-				text-decoration: none;
-
-
-				&:hover {
-					color: $color-our;
-				}
-			}
-		}
-
-
-		&.col-sm-5 {
-			padding-top: 18px;
-		}
-	}
-
-
-	&.col-sm-1 {
-		text-align: center;
-	}
+.latest .dot.big {
+	margin-bottom: 30px;
 }
 
 
-
-
-.latest {
-
-
-	.dot.big {
-		margin-bottom: 30px;
-	}
-
-
-	.explain {
-
-
-		h4 {
-			font-size: 2.5rem;
-		}
-
-
-		p {
-			font-size: 1.1rem;
-			color: $color-text
-;
-		}
-
-		.col-xs-12 {
-			min-height: 0;
-		}
-	}
+.latest .explain h4 {
+	font-size: 2.5rem;
 }
+
+
+.latest .explain p {
+	font-size: 1.1rem;
+	color: $color-text;
+}
+
+.latest .explain .col-xs-12 {
+	min-height: 0;
+}
+
 
 
 
@@ -185,7 +126,7 @@
 
 	.markdown-syntax {
 
-		p, li, ul, a {
+		p, li, ul {
 			color: $color-headline;
 			font-size: .95rem;
 		}
@@ -412,8 +353,6 @@
 	font-weight: 700;
 }
 
-
-
 .release-section-group {
 	flex: 1 1 100%;
 	padding: 0;
@@ -442,21 +381,6 @@
 	align-items: center;
 
 	box-sizing: border-box;
-}
-
-.release-other-files .release {
-	min-height: auto;
-	margin-bottom: 30px;
-}
-
-.release-other-files .release a {
-	display: inline-block;
-	margin-bottom: 10px;
-	margin-top: 10px;
-}
-
-.release-other-files .release p {
-	margin-top: 0;
 }
 
 
@@ -500,6 +424,8 @@
 }
 
 
+
+// Other files
 .release-other-files {
 	margin-top: 3rem;
 }
@@ -512,4 +438,20 @@
 .release-other-files small {
 	font-size: .8rem;
 	color: rgba($color-text, .5);
+}
+
+
+.release-other-files .release {
+	min-height: auto;
+	margin-bottom: 30px;
+}
+
+.release-other-files .release a {
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-top: 10px;
+}
+
+.release-other-files .release p {
+	margin-top: 0;
 }

--- a/OurUmbraco.Client/src/scss/pages/_release.scss
+++ b/OurUmbraco.Client/src/scss/pages/_release.scss
@@ -61,8 +61,8 @@
 
 .get-release {
 	line-height: 1.5;
-	padding: 2rem 0;
-	margin: 0 0 2.5rem ;
+	padding: 3rem 0;
+	margin: 0 0 3.5rem ;
 	border-bottom: 1px solid darken(whitesmoke, 5%);
 }
 
@@ -339,20 +339,6 @@
 }
 
 
-
-.release-header {
-	flex: 0 0 100%;
-	padding-bottom: 5px;
-	margin-bottom: 2.5rem;
-
-	border-bottom: 1px solid darken(whitesmoke, 5%);
-}
-
-.release-header h2 {
-	font-size: 1.6rem;
-	font-weight: 700;
-}
-
 .release-section-group {
 	flex: 1 1 100%;
 	padding: 0;
@@ -417,7 +403,13 @@
 	}
 }
 
-.release-section h3 {
+.release-page h2 {
+	font-size: 1.4rem;
+	font-weight: bold;
+	margin-bottom: 0;
+}
+
+.release-page h3 {
 	font-size: 1.1rem;
 	font-weight: bold;
 	margin-bottom: 0;

--- a/OurUmbraco.Client/src/scss/style.scss
+++ b/OurUmbraco.Client/src/scss/style.scss
@@ -16,6 +16,11 @@
 
 
 /**
+/* Utilities
+**/
+@import 'utilities/flexbox';
+
+/**
 /* Elements
 **/
 

--- a/OurUmbraco.Client/src/scss/utilities/_flexbox.scss
+++ b/OurUmbraco.Client/src/scss/utilities/_flexbox.scss
@@ -1,0 +1,67 @@
+/*
+
+    Flexbox
+
+*/
+
+.flex { display: flex; }
+.flex-inline { display: inline-flex; }
+
+.flex-column  { flex-direction: column; }
+.flex-wrap    { flex-wrap: wrap; }
+
+.items-start    { align-items: flex-start; }
+.items-end      { align-items: flex-end; }
+.items-center   { align-items: center; }
+.items-baseline { align-items: baseline; }
+.items-stretch  { align-items: stretch; }
+
+.self-start    { align-self: flex-start; }
+.self-end      { align-self: flex-end; }
+.self-center   { align-self: center; }
+.self-baseline { align-self: baseline; }
+.self-stretch  { align-self: stretch; }
+
+.justify-start   { justify-content: flex-start; }
+.justify-end     { justify-content: flex-end; }
+.justify-center  { justify-content: center; }
+.justify-between { justify-content: space-between; }
+.justify-around  { justify-content: space-around; }
+
+.content-start   { align-content: flex-start; }
+.content-end     { align-content: flex-end; }
+.content-center  { align-content: center; }
+.content-between { align-content: space-between; }
+.content-around  { align-content: space-around; }
+.content-stretch { align-content: stretch; }
+
+.flx-i {
+  flex: 1;
+}
+.flx-g0 {
+  flex-grow: 0;
+}
+.flx-s0 {
+  flex-shrink: 0;
+}
+.flx-b0 {
+  flex-basis: 0%;
+}
+.flx-g1 {
+  flex-grow: 1;
+}
+.flx-s1 {
+  flex-shrink: 1;
+}
+.flx-b1 {
+  flex-basis: 100%;
+}
+
+/* 1. Fix for Chrome 44 bug. https://code.google.com/p/chromium/issues/detail?id=506893 */
+.flex-auto {
+  flex: 1 1 auto;
+  min-width: 0; /* 1 */
+  min-height: 0; /* 1 */
+}
+
+.flex-none { flex: none; }

--- a/OurUmbraco.Site/masterpages/Release.master
+++ b/OurUmbraco.Site/masterpages/Release.master
@@ -147,10 +147,6 @@
 			                    {
 				                    <div class="get-release">
 
-                                        <div class="release-header">
-                                             <h2>Get it now</h2>
-                                        </div>
-
                                         <div class="release-section flex flex-row flex-wrap">
 
                                             <!-- Download button -->
@@ -166,7 +162,7 @@
                                                             <div class="release-section-action">
                                                                 <a class="button green" href="/ReleaseDownload?id=@item.Id" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@item.Name']);">Download Umbraco @Model.Name</a>
                                                             </div>
-                                                            <p>This is probably what you're going to need to get started. If you need documentation, please proceed to <strong>"Getting Started"</strong>.</p>
+                                                            <p>This is the main Umbraco download, generally you won't need anything else. You can find documentation under <strong>"Getting Started"</strong>.</p>
     						                                <small>Downloaded @numberOfDownloads times - uploaded @item.UploadDate.ToString("D")</small>
                                                         }
     					                            }

--- a/OurUmbraco.Site/masterpages/Release.master
+++ b/OurUmbraco.Site/masterpages/Release.master
@@ -5,22 +5,22 @@
 
 <asp:Content ID="Content1" ContentPlaceHolderId="Head" runat="server">
 </asp:Content>
-  
+
 <asp:Content ID="Content2" ContentPlaceHolderId="Main" runat="server">
     <umbraco:Macro ID="Macro6" Language="cshtml" runat="server">
         @{
             if(Request.Params["fromdownload"] != null) {
-                var downloads = Model.ReleaseDownload.Where("Visible");		
+                var downloads = Model.ReleaseDownload.Where("Visible");
 			    if(downloads.Any())
 			    {
                     var downloadIds = new List<int>();
 				    foreach (var item in downloads)
-					{					
+					{
                         downloadIds.Add(item.Id);
 			        }
                     Response.Redirect("/ReleaseDownload?id=" + downloadIds.First(), false);
 			    }
-            } 
+            }
         }
     </umbraco:Macro>
 <%
@@ -29,7 +29,7 @@
     var release = allReleases.First(x => x.version == currentPage.Name);
     var completedIssues = release.issues.Count(x => x.state == "Fixed");
     var totalIssues = release.issues.Count();
-    var percentComplete = Math.Round(((double) 100/totalIssues)*completedIssues);
+    var percentComplete = Math.Round(((double)100 / totalIssues) * completedIssues);
     var releaseDateParsed = DateTime.Now;
     if (release.releaseDate != string.Empty)
     {
@@ -38,7 +38,7 @@
 
     var releaseDate = release.releaseDate == "" ? "Not yet determined" : releaseDateParsed.ToString("dddd, MMMM d yyyy");
 
-    
+
     var umbracoHelper = new Umbraco.Web.UmbracoHelper(UmbracoContext.Current);
     var releaseContent = umbracoHelper.TypedContent(umbracoHelper.UmbracoContext.PageId);
     if (releaseContent != null)
@@ -60,7 +60,7 @@
 			<div class="sidebar-area">
 				<div class="sidebar-content">
 					<div class="content-wrapper">
-                        
+
 					<nav>
 						<ul class="level-1">
                             <%
@@ -102,150 +102,117 @@
                     <div>
                         <umbraco:Macro linkToCurrent="1" Alias="Breadcrumb" runat="server"></umbraco:Macro>
                     </div>
-                    
-                    <style>
-                        .release-page .explain h2 {
-                            margin-top: 12px;
-                            font-size: 2em;
-                            margin-bottom: .3rem;
-                            color: rgba(0,0,0,.8);
-                        }
 
-                        .release-page .dot {
-                            border: none;
-                        }
+                    <div class="explain flex items-center">
 
-                        .release-page .dot.big {
-                            position: relative;
-                            text-indent: 0;
-                            margin: 15px auto 0;
-                        }
+                         <div class="release-progress-indicator flex flex-wrap items-center">
 
-                        .release-page .chart {
-                            height: 60px;
-                            width: 60px;
-                            top: initial;
-                            left: initial;
-                            text-align: center;
-                        }
-
-                        .release-page .chart p {
-                            vertical-align: middle;
-                            line-height: 3.7rem;
-                            display: inline-block;
-                        }
-
-                        .release-page .chart canvas {
-                            top: 0px;
-                            left: 0px;
-                        }
-                        
-                        .statuses ul {
-                            list-style-type: none; 
-                        }
-                        .statuses ul li  { 
-                            position: relative;
-                            margin-bottom: 10px;
-                            padding-left: 10px;
-                        }
-                        .statuses li:before {
-                            position: absolute;
-                            top: -4px;
-                            left: -25px;
-                            font-size: 1.5em;
-                        }
-                    </style>
-
-                    <div class="row explain">
-                        <div class="col-sm-2">
-                            <span class="dot big progress">
+                             <span class="dot big progress">
 				                <div class="chart"  data-percent="<%= percentComplete %>">
                                     <p><%= percentComplete %>%</p>
 				                </div>
 			                </span>
-                        </div>
-                        <div class="col-sm-10">
-                            <h2>
-                                v<umbraco:Item ID="Item1" field="pageName" runat="server" />
-                            </h2>
-                            <small>Status: <span><%= release.released ? "Released" : "In Progress" %></span></small>
-                            <% if (release.released == false)
-                               { %>
-                            <h3>
-                                
-                                <span><%= percentComplete %>% complete</span>
-                                <span><%= 100 - percentComplete %>% in progress</span>
-                            </h3>
-                            <h3>Target release date: <span style="color:#5B5B5B"><%= releaseDate %></span></h3>
-                            <% } %>
-                            
-                            <umbraco:Macro ID="Macro5" Language="cshtml" runat="server">
-	                            @if(Model.HasValue("releaseNotes")) {
-		                            <small><p>@Model.releaseNotes</p></small>
-	                            }
-                            </umbraco:Macro>
-                            
+
+                             <span class="release-progress-version flex flex-column">
+                                <h2>
+                                    <strong><umbraco:Item ID="Item1" field="pageName" runat="server" /></strong>
+                                </h2>
+                                <small>Status: <span><%= release.released ? "Released" : "In Progress" %></span></small>
+                                <% if (release.released == false)
+                                    { %>
+                                <h3>
+
+                                    <span><%= percentComplete %>% complete</span>
+                                    <span><%= 100 - percentComplete %>% in progress</span>
+                                </h3>
+                                <h3>Target release date: <span style="color:#5B5B5B"><%= releaseDate %></span></h3>
+                                <% } %>
+
+                                <umbraco:Macro ID="Macro5" Language="cshtml" runat="server">
+	                                @if(Model.HasValue("releaseNotes")) {
+		                                <small><p>@Model.releaseNotes</p></small>
+	                                }
+                                </umbraco:Macro>
+                            </span>
+
                         </div>
                     </div>
-                    
+
                     <div>
                         <umbraco:Macro ID="Macro2" Language="cshtml" runat="server">
-		                    @{ 
-			                    var downloads = Model.ReleaseDownload.Where("Visible"); 	
-			                    var countIsOdd = ((downloads.Count() & 1) != 0) ? true : false;				
+		                    @{
+			                    var downloads = Model.ReleaseDownload.Where("Visible");
+			                    var countIsOdd = ((downloads.Count() & 1) != 0) ? true : false;
 			                    if(downloads.Any())
 			                    {
-				                    <div class="get-release row">
-					                    @foreach (var item in downloads)
-					                    {							
-						                    var background = item.IsFirst() ? "/images/releases/download.png" : "/media/2483095/download.png"; 
-						                    var width = (item.IsLast() && countIsOdd) ? 895 : 380;
-						                    var numberOfDownloads = 0;
-						                    int.TryParse(item.NumberOfDownloads, out numberOfDownloads);
-                                            numberOfDownloads = numberOfDownloads + OurUmbraco.Our.Utils.GetReleaseDownloadCount(item.Id);
-							                if(item.Name.Contains("WebPI") == false) 
-                                            {
-                                                <div class="release @(item.IsFirst() == false ? "bin" : "zip") col-sm-1">
-							                            <i class="icon-Download-alt"></i>
-					                            </div>
-					                            <div class="release @(item.IsFirst() == false ? "bin" : "zip") col-md-5">
-	
-						                            <h3><a href="/ReleaseDownload?id=@item.Id" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@item.Name']);">@item.Name</a></h3>
-                                                    @if(item.IsFirst())
-						                            {
-							                            <p>This is the main Umbraco download, generally you won't need anything else.</p>
-						                            }
-						                            <small>Downloaded @numberOfDownloads times - uploaded @item.UploadDate.ToString("D")</small>
-					                            </div>
-                                            } else {
-                                                <div style="display: none;"><a href="/ReleaseDownload?id=@item.Id" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@item.Name']);">@item.Name</a></div>
+				                    <div class="get-release">
+
+                                        <div class="release-header">
+                                             <h2>Get it now</h2>
+                                        </div>
+
+                                        <div class="release-section flex flex-row flex-wrap">
+
+                                            <!-- Download button -->
+                                            <div class="release-section-group">
+                                                <h3>Download and install</h3>
+                                                    @foreach (var item in downloads)
+                                                    {
+    						                            if (item.IsFirst())
+                                                        {
+                                                            var numberOfDownloads = 0;
+    						                                int.TryParse(item.NumberOfDownloads, out numberOfDownloads);
+                                                            numberOfDownloads = numberOfDownloads + OurUmbraco.Our.Utils.GetReleaseDownloadCount(item.Id);
+                                                            <div class="release-section-action">
+                                                                <a class="button green" href="/ReleaseDownload?id=@item.Id" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@item.Name']);">Download Umbraco @Model.Name</a>
+                                                            </div>
+                                                            <p>This is probably what you're going to need to get started. If you need documentation, please proceed to <strong>"Getting Started"</strong>.</p>
+    						                                <small>Downloaded @numberOfDownloads times - uploaded @item.UploadDate.ToString("D")</small>
+                                                        }
+    					                            }
+                                            </div>
+
+                                            <!-- NuGet installation -->
+                                            @if(Model.HasNuGet) {
+                                                <div class="release-section-group">
+                                                   <h3>Install by NuGet</h3>
+
+                                                   <div class="release-section-action">
+                                                        <code>PM&gt; Install-Package UmbracoCms -Version @Model.Name</code>
+
+                                                   </div>
+                                                   <p>Installs Umbraco Cms in your Visual Studio ASP.NET project. To install Umbraco Cms, run the following command in the Package Manager Console. <a target="_blank" href="https://nuget.org/packages/UmbracoCms/@Model.Name">Read more on nuget.com</a>
+                                                   </p>
+                                               </div>
                                             }
-					                    }
+
+                                        </div>
+
 				                    </div>
 			                    }
-		                    } 
+		                    }
                         </umbraco:Macro>
 
                         <div class="row markdown-syntax">
 
                             <div class="col-md-5">
-                                
+
                                 <% if (release.releaseDescription != string.Empty && currentPage.HasValue("bodyText") == false)
-                                   { %>
+                                    { %>
                                     <span>
                                         <h2>Summary</h2>
                                         <p><span><%= release.releaseDescription %></span></p>
                                     </span>
                                 <% } %>
-      
+
                             <umbraco:Macro ID="Macro3" Language="cshtml" runat="server">
 		                        @if(Model.HasValue("bodyText")) {
 			                        <h2>Release notes</h2>
 			                        @Model.BodyText
 		                        }
                             </umbraco:Macro>
-      
-	  
+
+
                             <h2>Related changes from the issue tracker</h2>
                             <div class="panel-wrapper">
                             <div class="panel-left">
@@ -264,8 +231,10 @@
                                                 <li class="<%= issue.StateIcon() %>" title="<%= issue.state %>">
                                                     <a href="http://issues.umbraco.org/issue/<%= issue.id %>" target="_blank"><%= issue.id %> - <%= issue.title %></a>
                                                 </li>
-                                            </ul>                
-                                        <% } } else { %>
+                                            </ul>
+                                        <% }
+                                        }
+                                        else { %>
                                             <p>No items to display</p>
                                         <% } %>
                                     </div>
@@ -282,8 +251,10 @@
                                                 <li class="<%= issue.StateIcon() %>" title="<%= issue.state %>">
                                                     <a href="http://issues.umbraco.org/issue/<%= issue.id %>" target="_blank"><%= issue.id %> - <%= issue.title %></a>
                                                 </li>
-                                            </ul>                
-                                        <% } } else { %>
+                                            </ul>
+                                        <% }
+                                        }
+                                        else { %>
                                             <p>No items to display</p>
                                         <% } %>
                                     </div>
@@ -300,18 +271,20 @@
                                                 <li class="<%= issue.StateIcon() %>" title="<%= issue.state %>">
                                                     <a href="http://issues.umbraco.org/issue/<%= issue.id %>" target="_blank"><%= issue.id %> - <%= issue.title %></a>
                                                 </li>
-                                            </ul>                
-                                        <% } } else { %>
+                                            </ul>
+                                        <% }
+                                        }
+                                        else { %>
                                             <p>No items to display</p>
                                         <% } %>
                                     </div>
                                 </div>
-          
+
                                     </div>
                             </div>
 
                             </div><!-- col-md-5 -->
-                                
+
                             <div class="col-md-5 col-md-offset-2">
 
                                 <h2>Getting started</h2>
@@ -327,26 +300,52 @@
                                 <p>You'll find our über active community working hard to help each other at Our Umbraco: <a href="http://our.umbraco.org">http://our.umbraco.org</a></p>
                                 <h2>Upgrading from older versions</h2>
                                 <p>Make sure to read the <a href="http://our.umbraco.org/documentation/Installation/Upgrading/">upgrade instructions</a> before you attempt an upgrade.</p>
-        
+
                                 <umbraco:Macro ID="Macro4" runat="server" Language="cshtml">
                                     <h2>Found a bug?</h2>
                                     <p>We're happy to help you with any problems you encounter, so please report them in <a href="http://issues.umbraco.org/issues/U4">the issue tracker</a> and use the “Affected versions” field to set it to @Model.Name. <br />Do a search first though, if the issue already exists, give it an extra vote.</p>
-        
+
                                     @if(Model.HasValue("linkToChangeset")) {
                                         <h2>Source code</h2>
                                         <p>The source for <a href="@Model.LinkToChangeset">this specific release is available for download from the repository</a> (click the "ZIP" button).</p>
                                     }
-            
-                                    @if(Model.HasNuGet) {
-                                        <h2>Also available on NuGet</h2>
-                
-                                        <div class="nuget-badge">
-                                            <a href="https://nuget.org/packages/UmbracoCms/@Model.Name">
-                                                <p><code>PM&gt; Install-Package UmbracoCms -Version @Model.Name</code></p>
-                                            </a>
+
+                                    <!-- Other files -->
+                                    @{
+        			                    var downloads = Model.ReleaseDownload.Where("Visible");
+        			                    var countIsOdd = ((downloads.Count() & 1) != 0) ? true : false;
+        			                    if(downloads.Any())
+        			                    {
+
+                                         <div class="release-other-files">
+                                             <h2>All files</h2>
+
+    					                    @foreach (var item in downloads)
+    					                    {
+    						                    var background = item.IsFirst() ? "/images/releases/download.png" : "/media/2483095/download.png";
+    						                    var width = (item.IsLast() && countIsOdd) ? 895 : 380;
+    						                    var numberOfDownloads = 0;
+    						                    int.TryParse(item.NumberOfDownloads, out numberOfDownloads);
+                                                numberOfDownloads = numberOfDownloads + OurUmbraco.Our.Utils.GetReleaseDownloadCount(item.Id);
+    							                if(item.Name.Contains("WebPI") == false)
+                                                {
+    					                            <div class="release @(item.IsFirst() == false ? "bin" : "zip")">
+    						                            <div><strong><a href="/ReleaseDownload?id=@item.Id" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@item.Name']);">@item.Name</a></strong></div>
+                                                        @if(item.IsFirst())
+    						                            {
+    							                            <p>This is the main Umbraco download, generally you won't need anything else.</p>
+    						                            }
+    						                            <small>Downloaded @numberOfDownloads times - uploaded @item.UploadDate.ToString("D")</small>
+    					                            </div>
+                                                } else {
+                                                    <div style="display: none;"><a href="/ReleaseDownload?id=@item.Id" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@item.Name']);">@item.Name</a></div>
+                                                }
+    					                    }
                                         </div>
-                
-                                    }
+
+        			                    }
+        		                    }
+
                                 </umbraco:Macro>
 
                             </div><!-- col-md-5 col-md-offset-2 -->
@@ -362,7 +361,7 @@
 </asp:Content>
 
 <asp:Content ContentPlaceHolderId="EndScripts" runat="server">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/easy-pie-chart/2.1.4/jquery.easypiechart.min.js"></script>    
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/easy-pie-chart/2.1.4/jquery.easypiechart.min.js"></script>
     <script type="text/javascript">
         setTimeout(function () {
             $('.chart').easyPieChart({


### PR DESCRIPTION
I did some basic cleanup of classes and deleted unused styles along with the changes of the call to action for downloading a release. I also updated some packages and commented out the Combine Media Queries as it seems broken at the moment. Added utility file to support Flexbox.

Most `scss` files is cleanup or changes to . https://github.com/umbraco/OurUmbraco/commit/7ffb0286e3a8ec21f1a3f268ea7bc58143bf279e is where the magic happens.