### PR TITLE
Remove viewport meta properties preventing zoom

### DIFF
--- a/OurUmbraco.Site/Views/Master.cshtml
+++ b/OurUmbraco.Site/Views/Master.cshtml
@@ -43,7 +43,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="alternate" type="application/rss+xml" title="Latest packages" href="//our.umbraco.org/rss/projects" />
     <link rel="alternate" type="application/rss+xml" title="Package updates" href="//our.umbraco.org/rss/projectsupdate" />


### PR DESCRIPTION
Preventing zoom is bad for accessibility as you cannot zoom into the website on mobile viewports. 

See http://alwaystwisted.com/articles/2013-01-10-dont-do-this-in-responsive-web-development for more information.

