### PR TITLE
Fixed typo on Roadmap.cshtml preventing ReleaseDescription from being displayed

### DIFF
--- a/OurUmbraco.Site/Views/RoadMap.cshtml
+++ b/OurUmbraco.Site/Views/RoadMap.cshtml
@@ -90,7 +90,9 @@
                         <div class="row explain">
                             <div class="col-xs-12">
                                 <h4 class="text-right"><a href="/contribute/releases/@(release.version.Replace(".",""))">v@(release.version)</a></h4>
-                                <small><span>@release.releaseDescription</span></small>
+                                @if (release.releaseDescription != string.Empty) {
+                                    <small><span>@Html.Raw(release.releaseDescription)</span></small>
+                                }
                             </div>
                             <div class="col-xs-6">
                                 <div class="changes">

--- a/OurUmbraco.Site/Views/RoadMap.cshtml
+++ b/OurUmbraco.Site/Views/RoadMap.cshtml
@@ -90,7 +90,7 @@
                         <div class="row explain">
                             <div class="col-xs-12">
                                 <h4 class="text-right"><a href="/contribute/releases/@(release.version.Replace(".",""))">v@(release.version)</a></h4>
-                                <small><span>release.releaseDescription</span></small>
+                                <small><span>@release.releaseDescription</span></small>
                             </div>
                             <div class="col-xs-6">
                                 <div class="changes">


### PR DESCRIPTION
Very small fix which will allow the release description to be displayed instead of `release.releaseDescription`.