### PR TITLE
Fixes issue #OUR-449.

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_packages.scss
+++ b/OurUmbraco.Client/src/scss/elements/_packages.scss
@@ -90,6 +90,7 @@ body.packages {
 			height: auto;
 			display: block;
 			vertical-align: middle;
+            width: 50px;
 			
 			@media (min-width: $md) {
 

--- a/OurUmbraco.Client/src/scss/sections/_forum.scss
+++ b/OurUmbraco.Client/src/scss/sections/_forum.scss
@@ -157,6 +157,10 @@ section.forum {
 		max-width: 112px;
 		height: auto;
 
+        .package-forum-activity & {
+            border-radius: 0;
+        }
+
 		@media (min-width: $md) {
 			width: 58px;
 		}

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -185,7 +185,7 @@
                                 defaultScreenshot = childContent.GetPropertyValue("defaultScreenshotPath", false, "/css/img/package2.png");
                             }
                         }
-                        <img src="@Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=50&height=50&format=png" />
+                        <img src="@Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=100&height=100&format=png" />
                     </div>
                     <div class="col-xs-10 col-md-6">
                         <div class="forum-thread-text">


### PR DESCRIPTION
Fixed a couple things:

- Doubled the image size on the package listing and set it smaller with the CSS so it displays nicely for retina
- Removed the border-radius on profile pages for package listings so the icons are consistent