### PR TITLE
Fix issues with filtering projects/packages

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_sidebar.scss
+++ b/OurUmbraco.Client/src/scss/elements/_sidebar.scss
@@ -143,7 +143,8 @@ html {
             margin-left: 5px;
             padding-left: 10px;
             transition: max-height 300ms ease-in-out;
-            li.active > a *{
+            li.active > a *,
+            li.active > h3 {
                 color: darken($color-our, 20%);
             }
             li.open > ul {

--- a/OurUmbraco.Site/Views/Projects.cshtml
+++ b/OurUmbraco.Site/Views/Projects.cshtml
@@ -56,21 +56,35 @@
     <script type="text/javascript">
         function getUrlVars() {
             var vars = [], hash;
-            var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-            for (var i = 0; i < hashes.length; i++) {
-                hash = hashes[i].split('=');
-                vars.push(hash[0]);
-                vars[hash[0]] = hash[1];
+            var location = window.location;
+            var queryIndex = location.href.indexOf('?');
+            if (queryIndex >= 0) {
+                var hashes = location.href.slice(queryIndex + 1).split('&');
+                for (var i = 0; i < hashes.length; i++) {
+                    hash = hashes[i].split('=');
+                    vars.push(hash[0]);
+                    vars[hash[0]] = hash[1];
+                }
             }
             return vars;
         }
+
         var query = getUrlVars();
-        var filter = '.filter-' + query[0];
-        $(filter).addClass('open');
+
+        // test if any parameters are available
+        if (query.length && query[0]) { 
+            var filter = '.filter-' + query[0];
+            var filterElem = $(filter);
+
+            // test if element exists
+            if (filterElem.length) {
+                filterElem.addClass('active open');
+            }
+        }
 
         $('.level-1>li').on('click', function () {
-            $('.level-1>li').removeClass('open');
-            $(this).addClass('open');
+            $('.level-1>li').removeClass('active open');
+            $(this).addClass('active open');
         });
     </script>
 }


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/OUR-460

After upgradering jQuery version from 1.7.2 to 1.9.1, because Fancybox v3 requires jQuery 1.9+, it seems to break the project filter functionality due the way to select elements `jQuery(htmlString)` versus `jQuery(selectorString)`
https://stackoverflow.com/a/23960371
https://github.com/nathanvda/cocoon/issues/127

It seems to happen, where there is no querystring, where the `getUrlVars` function on this page was returning undefined. I have modified it to return an empty array instead.

Currently the filter function works if querystring contains any values, e.g. `?version=7` or just `?test=1` (which doesn't return the console error).