### PR TITLE
Updated the implementation for GitHub contributors

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Home/GitHubContributors.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Home/GitHubContributors.cshtml
@@ -1,4 +1,4 @@
-﻿@model OurUmbraco.Community.Models.GitHubContributorsModel
+﻿@model OurUmbraco.Community.GitHub.Models.GitHubContributorsModel
 
 @if (Model.Contributors.Any())
 {

--- a/OurUmbraco/Community/Controllers/GitHubContributorController.cs
+++ b/OurUmbraco/Community/Controllers/GitHubContributorController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Web.Mvc;
+using OurUmbraco.Community.GitHub;
 using OurUmbraco.Community.Models;
 using OurUmbraco.Our.Api;
 using RestSharp;
@@ -121,7 +122,7 @@ namespace OurUmbraco.Community.Controllers
 
             string[] login = System.IO.File.ReadAllLines(configPath).Where(x => x.Trim() != "").Distinct().ToArray();
 
-            var githubController = new GitHubController();
+            var githubController = new GitHubRepository();
             var gitHubContributors = new List<GitHubContributorModel>();
             foreach (var repo in Repositories)
             {

--- a/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
+++ b/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Text;
 using System.Web.Mvc;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using OurUmbraco.Community.GitHub.Models;
 using OurUmbraco.Community.GitHub.Models.Cached;
-using RestSharp;
 using Umbraco.Core.Logging;
 using Umbraco.Web.Mvc;
 
@@ -16,43 +11,6 @@ namespace OurUmbraco.Community.GitHub.Controllers
 {
     public class GitHubContributorController : SurfaceController
     {
-        /// <summary>
-        /// Repositories to include in the combination of contributions
-        /// </summary>
-        private readonly string[] Repositories =
-        {
-            "Umbraco-CMS",
-            "UmbracoDocs",
-            "OurUmbraco",
-            "Umbraco.Deploy.Contrib",
-            "Umbraco.Courier.Contrib",
-            "Umbraco.Deploy.ValueConnectors"
-        };
-
-        protected string JsonPath
-        {
-            get { return Server.MapPath("~/App_Data/TEMP/GithubContributors.json"); }
-        }
-
-        public List<GitHubCachedGlobalContributorModel> GetCachedContributors()
-        {
-
-            if (!System.IO.File.Exists(JsonPath)) throw new Exception("The JSON file doesn't exist on disk");
-
-
-            List<GitHubCachedGlobalContributorModel> temp = new List<GitHubCachedGlobalContributorModel>();
-
-            // Parse the JSON file from disk
-            foreach (JToken token in Skybrud.Essentials.Json.JsonUtils.LoadJsonArray(JsonPath))
-            {
-
-                temp.Add(token.ToObject<GitHubCachedGlobalContributorModel>());
-
-            }
-
-            return temp;
-
-        }
 
         /// <summary>
         /// Gets data for all GitHub contributors for all listed Umbraco repositories, 
@@ -64,109 +22,55 @@ namespace OurUmbraco.Community.GitHub.Controllers
             var model = new GitHubContributorsModel();
             model.Contributors = new List<GitHubCachedGlobalContributorModel>();
 
-            try
-            {
+            GitHubService service = new GitHubService();
 
-                // If the file exists on disk and hasn't expired (AKA not older than one day), we should just load that
-                if (force == false && System.IO.File.Exists(JsonPath) && System.IO.File.GetLastWriteTimeUtc(JsonPath) >= DateTime.UtcNow.AddDays(-1))
-                {
-                    model.Contributors = GetCachedContributors();
-                    return PartialView("~/Views/Partials/Home/GitHubContributors.cshtml", model);
-                }
+
+            if (force)
+            {
 
                 try
                 {
-                    // Load the contributors via the GitHub API and map to the cached model
-                    var contributors = GetContributors().Select(x => new GitHubCachedGlobalContributorModel(x));
 
-                    // Serialize the contributors to raw JSON
-                    string rawJson = JsonConvert.SerializeObject(contributors, Formatting.Indented);
+                    // Update the cached contributors
+                    GitHubContributorsResult result = service.UpdateOverallContributors();
 
-                    // Save the JSON to disk
-                    System.IO.File.WriteAllText(JsonPath, rawJson, Encoding.UTF8);
+                    // Update the model with the contributors
+                    model.Contributors = result.Contributors.Select(x => new GitHubCachedGlobalContributorModel(x)).ToList();
 
-                    model.Contributors = contributors.ToList();
                 }
                 catch (Exception ex)
                 {
-                    // Log the error so we can debug it later
-                    LogHelper.Error<GitHubContributorController>("Unable to load GitHub contributors from the GitHub API", ex);
 
-                    // Load the contributors from the cache (if we have any)
-                    model.Contributors = GetCachedContributors();
+                    // Log the error so we can debug it later
+                    LogHelper.Error<GitHubContributorController>("Unable to load GitHub contributors from the GitHub", ex);
+
                 }
 
             }
-            catch (Exception ex)
+            else if (System.IO.File.Exists(service.JsonPath))
             {
-                // Log the error so we can debug it later
-                LogHelper.Error<GitHubContributorController>("Unable to load GitHub contributors from the GitHub API", ex);
+
+                try
+                {
+
+                    // Update the model with the contributors
+                    model.Contributors = service.GetOverallContributorsFromDisk();
+
+                }
+                catch (Exception ex)
+                {
+                    
+                    // Log the error so we can debug it later
+                    LogHelper.Error<GitHubContributorController>("Unable to load GitHub contributors from the GitHub API or cache", ex);
+
+                }
 
             }
 
             return PartialView("~/Views/Partials/Home/GitHubContributors.cshtml", model);
-        }
-
-        public List<GitHubGlobalContributorModel> GetContributors()
-        {
-
-
-            string configPath = Server.MapPath("~/config/githubhq.txt");
-            if (!System.IO.File.Exists(configPath))
-            {
-                LogHelper.Debug<GitHubContributorController>("Config file was not found: " + configPath);
-                throw new Exception("Config file was not found: " + configPath);
-            }
-
-            string[] login = System.IO.File.ReadAllLines(configPath).Where(x => x.Trim() != "").Distinct().ToArray();
-
-            var githubController = new GitHubService();
-            var gitHubContributors = new List<GitHubContributorModel>();
-            foreach (var repo in Repositories)
-            {
-                var response = githubController.GetAllRepoContributors(repo);
-                if (response.StatusCode == HttpStatusCode.OK &&
-                    response.ResponseStatus == ResponseStatus.Completed)
-                {
-                    gitHubContributors.AddRange(response.Data);
-                }
-                else
-                {
-                    LogHelper.Warn<IGitHubContributorsModel>(string.Format("Invalid HTTP response for repository {0}", repo));
-                }
-            }
-
-            // filter to only include items from the last year (if we ran 4.6.1 we could have used ToUnixTimeSeconds())
-            var filteredRange = DateTime.UtcNow.AddYears(-1).Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
-
-            foreach (var contrib in gitHubContributors)
-            {
-                var contribWeeks = contrib.Weeks.Where(x => x.W >= filteredRange).ToList();
-                contrib.TotalAdditions = contribWeeks.Sum(x => x.A);
-                contrib.TotalDeletions = contribWeeks.Sum(x => x.D);
-                contrib.Total = contribWeeks.Sum(x => x.C);
-            }
-
-            var filteredContributors = gitHubContributors
-                .Where(g => !login.Contains(g.Author.Login))
-                .GroupBy(g => g.Author.Id)
-                .OrderByDescending(c => c.Sum(g => g.Total));
-
-            List<GitHubGlobalContributorModel> temp = new List<GitHubGlobalContributorModel>();
-
-            foreach (var group in filteredContributors)
-            {
-                var contributor = new GitHubGlobalContributorModel(group);
-                if (contributor.TotalCommits > 0)
-                {
-                    temp.Add(contributor);
-                }
-            }
-
-            return temp;
-
-
+        
         }
 
     }
+
 }

--- a/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
+++ b/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
@@ -2,19 +2,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Web.Mvc;
-using OurUmbraco.Community.GitHub;
-using OurUmbraco.Community.Models;
-using OurUmbraco.Our.Api;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OurUmbraco.Community.GitHub.Models;
 using RestSharp;
-using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
 using Umbraco.Web.Mvc;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
-using System.Text;
 
-namespace OurUmbraco.Community.Controllers
+namespace OurUmbraco.Community.GitHub.Controllers
 {
     public class GitHubContributorController : SurfaceController
     {

--- a/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
+++ b/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
@@ -120,7 +120,7 @@ namespace OurUmbraco.Community.GitHub.Controllers
 
             string[] login = System.IO.File.ReadAllLines(configPath).Where(x => x.Trim() != "").Distinct().ToArray();
 
-            var githubController = new GitHubRepository();
+            var githubController = new GitHubService();
             var gitHubContributors = new List<GitHubContributorModel>();
             foreach (var repo in Repositories)
             {

--- a/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
+++ b/OurUmbraco/Community/GitHub/Controllers/GitHubContributorController.cs
@@ -7,6 +7,7 @@ using System.Web.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OurUmbraco.Community.GitHub.Models;
+using OurUmbraco.Community.GitHub.Models.Cached;
 using RestSharp;
 using Umbraco.Core.Logging;
 using Umbraco.Web.Mvc;

--- a/OurUmbraco/Community/GitHub/GitHubRepository.cs
+++ b/OurUmbraco/Community/GitHub/GitHubRepository.cs
@@ -2,9 +2,9 @@
 using OurUmbraco.Community.Models;
 using RestSharp;
 
-namespace OurUmbraco.Our.Api
+namespace OurUmbraco.Community.GitHub
 {
-    public class GitHubController
+    public class GitHubRepository
     {
         private const string RepositoryOwner = "Umbraco";
         private const string GitHubApiClient = "https://api.github.com";

--- a/OurUmbraco/Community/GitHub/GitHubRepository.cs
+++ b/OurUmbraco/Community/GitHub/GitHubRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using OurUmbraco.Community.GitHub.Models;
 using OurUmbraco.Community.Models;
 using RestSharp;
 

--- a/OurUmbraco/Community/GitHub/GitHubService.cs
+++ b/OurUmbraco/Community/GitHub/GitHubService.cs
@@ -1,15 +1,64 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Web.Hosting;
+using Newtonsoft.Json;
 using OurUmbraco.Community.GitHub.Models;
-using OurUmbraco.Community.Models;
+using OurUmbraco.Community.GitHub.Models.Cached;
 using RestSharp;
+using Skybrud.Essentials.Time;
+using Umbraco.Core.Logging;
 
 namespace OurUmbraco.Community.GitHub
 {
     public class GitHubService
     {
+        
         private const string RepositoryOwner = "Umbraco";
         private const string GitHubApiClient = "https://api.github.com";
         private const string UserAgent = "OurUmbraco";
+
+        protected string JsonPath
+        {
+            get { return HostingEnvironment.MapPath("~/App_Data/TEMP/GithubContributors.json"); }
+        }
+
+        /// <summary>
+        /// Gets a list of the repositories that should be included in the list of contributors.
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetRepositories()
+        {
+            return new[] {
+                "Umbraco-CMS",
+                "UmbracoDocs",
+                "OurUmbraco",
+                "Umbraco.Deploy.Contrib",
+                "Umbraco.Courier.Contrib",
+                "Umbraco.Deploy.ValueConnectors"
+            };
+        }
+
+        /// <summary>
+        /// Gets a list of contributors (<see cref="GitHubContributorModel"/>) for a single GitHub repository.
+        /// </summary>
+        /// <param name="repo">The alias (slug) of the repository.</param>
+        /// <returns>A list of <see cref="GitHubContributorModel"/>.</returns>
+        public IRestResponse<List<GitHubContributorModel>> GetRepositoryContributors(string repo)
+        {
+
+            // Initialize the request
+            RestClient client = new RestClient(GitHubApiClient);
+            RestRequest request = new RestRequest(string.Format("/repos/{0}/{1}/stats/contributors", RepositoryOwner, repo), Method.GET);
+            client.UserAgent = UserAgent;
+
+            // Make the request to the GitHub API
+            return client.Execute<List<GitHubContributorModel>>(request);
+
+        }
 
         /// <summary>
         /// Get all contributors from GitHub Umbraco repositories
@@ -24,5 +73,179 @@ namespace OurUmbraco.Community.GitHub
             var response = client.Execute<List<GitHubContributorModel>>(request);
             return response;
         }
+
+        public GitHubContributorsResult GetOverallContributors(int maxAttempts = 3)
+        {
+
+            // Initialize a new StringBuilder for logging/testing purposes
+            StringBuilder sb = new StringBuilder();
+
+            // Map the path to the file containg HQ members that should be excluded in the list
+            string configPath = HostingEnvironment.MapPath("~/config/githubhq.txt");
+            if (!System.IO.File.Exists(configPath))
+            {
+                LogHelper.Debug<GitHubService>("Config file was not found: " + configPath);
+                throw new Exception("Config file was not found: " + configPath);
+            }
+
+            // Parse the logins (usernames)
+            string[] login = System.IO.File.ReadAllLines(configPath).Where(x => x.Trim() != "").Distinct().ToArray();
+
+            // A dictionary for the response of each repository
+            Dictionary<string, IRestResponse<List<GitHubContributorModel>>> responses = new Dictionary<string, IRestResponse<List<GitHubContributorModel>>>();
+
+            // Hashset for keeping track of missing responses
+            HashSet<string> missing = new HashSet<string>();
+
+            Log(sb, "Attempt 1");
+
+            // Iterate over the repositories
+            foreach (string repo in GetRepositories())
+            {
+
+                Log(sb, "-> Making request to " + GitHubApiClient + string.Format("/repos/{0}/{1}/stats/contributors", RepositoryOwner, repo));
+
+                // Make the request to the GitHub API
+                IRestResponse<List<GitHubContributorModel>> response = GetRepositoryContributors(repo);
+
+                Log(sb, "  -> " + ((int) response.StatusCode) + " -> " + response.StatusCode);
+
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.OK:
+                        responses[repo] = response;
+                        break;
+                    case HttpStatusCode.Accepted:
+                        missing.Add(repo);
+                        break;
+                    default:
+                        Log(sb, "Failed getting contributors for repository " + repo + ": " + response.StatusCode + "\r\n\r\n" + response.Content);
+                        throw new Exception("Failed getting contributors for repository " + repo + ": " + response.StatusCode);
+                }
+
+            }
+
+
+            for (int i = 2; i <= maxAttempts; i++)
+            {
+
+                // Break the loop if there are no missing repositories
+                if (missing.Count == 0)
+                {
+                    break;
+                }
+
+                // Wait for a few seconds so the GitHub cache hopefully has been populated
+                Thread.Sleep(5000);
+
+                Log(sb, "Attempt " + i);
+
+                foreach (string repo in GetRepositories())
+                {
+
+                    // Make the request to the GitHub API
+                    IRestResponse<List<GitHubContributorModel>> response = GetRepositoryContributors(repo);
+
+                    // Error checking
+                    switch (response.StatusCode) {
+
+                        case HttpStatusCode.OK:
+                            
+                            // Set the response in the dictionary
+                            responses[repo] = response;
+
+                            // Remove the repository from queue
+                            missing.Remove(repo);
+
+                            break;
+
+                        case HttpStatusCode.Accepted:
+                            // zZzZz
+                            break;
+
+                        default:
+                            Log(sb, "Failed getting contributors for repository " + repo + ": " + response.StatusCode + "\r\n\r\n" + response.Content);
+                            throw new Exception("Failed getting contributors for repository " + repo + ": " + response.StatusCode + "\r\n\r\n" + response.Content);
+                    
+                    }
+
+                }
+
+            }
+
+            // (╯°□°)╯︵ ┻━┻
+            if (missing.Count > 0)
+            {
+                Log(sb, "Unable to get contributors for one or more repositories:\r\n" + String.Join("\r\n", missing));
+                throw new Exception("Unable to get contributors for one or more repositories");
+            }
+
+            // filter to only include items from the last year (if we ran 4.6.1 we could have used ToUnixTimeSeconds())
+            int filteredRange = TimeUtils.GetUnixTimeFromDateTime(DateTime.UtcNow.AddYears(-1));
+
+            List<GitHubContributorModel> contributors = new List<GitHubContributorModel>();
+
+            // Iterate over the responses (we don't care about the keys at this point)
+            foreach (IRestResponse<List<GitHubContributorModel>> response in responses.Values)
+            {
+
+                // Iterate over the contributors of the individual response
+                foreach (GitHubContributorModel contrib in response.Data)
+                {
+
+                    // Make sure we only get weeks from the past year
+                    var contribWeeks = contrib.Weeks.Where(x => x.W >= filteredRange).ToList();
+
+                    // Populate the properties
+                    contrib.TotalAdditions = contribWeeks.Sum(x => x.A);
+                    contrib.TotalDeletions = contribWeeks.Sum(x => x.D);
+                    contrib.Total = contribWeeks.Sum(x => x.C);
+
+                    // Append the contributor to the aggregated list
+                    contributors.Add(contrib);
+
+                }
+
+            }
+
+            // Group and sort the contributors from each repository
+            List<GitHubGlobalContributorModel> globalContributors = contributors
+                .Where(g => g.Total > 0 && !login.Contains(g.Author.Login))
+                .GroupBy(g => g.Author.Id)
+                .Select(g => new GitHubGlobalContributorModel(g))
+                .OrderByDescending(c => c.TotalCommits)
+                .ThenByDescending(c => c.TotalAdditions)
+                .ThenByDescending(c => c.TotalDeletions)
+                .ToList();
+
+            return new GitHubContributorsResult(globalContributors, sb + "");
+
+        }
+
+        public GitHubContributorsResult UpdateOverallContributors(int maxAttempts = 3)
+        {
+
+            // Load the contributors via the GitHub API
+            GitHubContributorsResult result = GetOverallContributors(maxAttempts);
+
+            // Map the contributors to the cached model
+            IEnumerable<GitHubCachedGlobalContributorModel> contributors = result.Contributors.Select(x => new GitHubCachedGlobalContributorModel(x));
+
+            // Serialize the contributors to raw JSON
+            string rawJson = JsonConvert.SerializeObject(contributors, Formatting.Indented);
+
+            // Save the JSON to disk
+            System.IO.File.WriteAllText(JsonPath, rawJson, Encoding.UTF8);
+
+            return result;
+
+        }
+
+        private void Log(StringBuilder sb, string str)
+        {
+            sb.AppendLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " " + str);
+        }
+
     }
+
 }

--- a/OurUmbraco/Community/GitHub/GitHubService.cs
+++ b/OurUmbraco/Community/GitHub/GitHubService.cs
@@ -6,9 +6,11 @@ using System.Text;
 using System.Threading;
 using System.Web.Hosting;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using OurUmbraco.Community.GitHub.Models;
 using OurUmbraco.Community.GitHub.Models.Cached;
 using RestSharp;
+using Skybrud.Essentials.Json;
 using Skybrud.Essentials.Time;
 using Umbraco.Core.Logging;
 
@@ -21,10 +23,7 @@ namespace OurUmbraco.Community.GitHub
         private const string GitHubApiClient = "https://api.github.com";
         private const string UserAgent = "OurUmbraco";
 
-        public string JsonPath
-        {
-            get { return HostingEnvironment.MapPath("~/App_Data/TEMP/GithubContributors.json"); }
-        }
+        public readonly string JsonPath =  HostingEnvironment.MapPath("~/App_Data/TEMP/GithubContributors.json");
 
         /// <summary>
         /// Gets a list of the repositories that should be included in the list of contributors.
@@ -241,6 +240,24 @@ namespace OurUmbraco.Community.GitHub
 
         }
 
+        /// <summary>
+        /// Attempts to load the JSON file at <see cref="JsonPath"/>. If successful, the global list of contributors
+        /// will be returned.
+        /// </summary>
+        /// <returns>A list of <see cref="GitHubCachedGlobalContributorModel"/>.</returns>
+        public List<GitHubCachedGlobalContributorModel> GetOverallContributorsFromDisk()
+        {
+            return (
+                from JObject item in JsonUtils.LoadJsonArray(JsonPath)
+                select item.ToObject<GitHubCachedGlobalContributorModel>()
+            ).ToList();
+        }
+
+        /// <summary>
+        /// Appends the specified <paramref name="str"/> to <paramref name="sb"/>. Mostly used for debugging purposes.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> representing the log.</param>
+        /// <param name="str">The string to be added to <paramref name="sb"/>.</param>
         private void Log(StringBuilder sb, string str)
         {
             sb.AppendLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " " + str);

--- a/OurUmbraco/Community/GitHub/GitHubService.cs
+++ b/OurUmbraco/Community/GitHub/GitHubService.cs
@@ -5,7 +5,7 @@ using RestSharp;
 
 namespace OurUmbraco.Community.GitHub
 {
-    public class GitHubRepository
+    public class GitHubService
     {
         private const string RepositoryOwner = "Umbraco";
         private const string GitHubApiClient = "https://api.github.com";

--- a/OurUmbraco/Community/GitHub/GitHubService.cs
+++ b/OurUmbraco/Community/GitHub/GitHubService.cs
@@ -21,7 +21,7 @@ namespace OurUmbraco.Community.GitHub
         private const string GitHubApiClient = "https://api.github.com";
         private const string UserAgent = "OurUmbraco";
 
-        protected string JsonPath
+        public string JsonPath
         {
             get { return HostingEnvironment.MapPath("~/App_Data/TEMP/GithubContributors.json"); }
         }

--- a/OurUmbraco/Community/GitHub/Models/Cached/GitHubCachedGlobalContributorModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/Cached/GitHubCachedGlobalContributorModel.cs
@@ -1,0 +1,36 @@
+namespace OurUmbraco.Community.GitHub.Models.Cached
+{
+
+    public class GitHubCachedGlobalContributorModel
+    {
+
+        public int AuthorId { get; set; }
+
+        public string AuthorLogin { get; set; }
+
+        public string AuthorUrl { get; set; }
+
+        public string AuthorAvatarUrl { get; set; }
+
+        public int TotalCommits { get; set; }
+
+        public int TotalAdditions { get; set; }
+
+        public int TotalDeletions { get; set; }
+
+        public GitHubCachedGlobalContributorModel() { }
+
+        public GitHubCachedGlobalContributorModel(GitHubGlobalContributorModel contributor)
+        {
+            AuthorId = contributor.Author.Id;
+            AuthorLogin = contributor.Author.Login;
+            AuthorUrl = contributor.Author.HtmlUrl;
+            AuthorAvatarUrl = contributor.Author.AvatarUrl;
+            TotalCommits = contributor.TotalCommits;
+            TotalAdditions = contributor.TotalAdditions;
+            TotalDeletions = contributor.TotalDeletions;
+        }
+
+    }
+
+}

--- a/OurUmbraco/Community/GitHub/Models/GitHubContributorsModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/GitHubContributorsModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using OurUmbraco.Community.GitHub.Models.Cached;
 
 namespace OurUmbraco.Community.GitHub.Models
 {

--- a/OurUmbraco/Community/GitHub/Models/GitHubContributorsModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/GitHubContributorsModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
-using OurUmbraco.Community.Controllers;
 
-namespace OurUmbraco.Community.Models
+namespace OurUmbraco.Community.GitHub.Models
 {
     public class GitHubContributorsModel : IGitHubContributorsModel
     {

--- a/OurUmbraco/Community/GitHub/Models/GitHubContributorsResult.cs
+++ b/OurUmbraco/Community/GitHub/Models/GitHubContributorsResult.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace OurUmbraco.Community.GitHub.Models {
+    
+    /// <summary>
+    /// Class wrapping the overall result of GitHub contributors. This is a class so we can add other properties than
+    /// just the contributors - eg. a log for debugging purposes.
+    /// </summary>
+    public class GitHubContributorsResult
+    {
+
+        public List<GitHubGlobalContributorModel> Contributors { get; private set; }
+
+        public string Log { get; private set; }
+
+        public GitHubContributorsResult(List<GitHubGlobalContributorModel> contributors, string log = "")
+        {
+            Contributors = contributors;
+            Log = log;
+        }
+
+    }
+
+}

--- a/OurUmbraco/Community/GitHub/Models/GitHubGlobalContributorModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/GitHubGlobalContributorModel.cs
@@ -3,39 +3,6 @@ using System.Linq;
 
 namespace OurUmbraco.Community.GitHub.Models
 {
-
-    public class GitHubCachedGlobalContributorModel
-    {
-
-        public int AuthorId { get; set; }
-
-        public string AuthorLogin { get; set; }
-
-        public string AuthorUrl { get; set; }
-
-        public string AuthorAvatarUrl { get; set; }
-
-        public int TotalCommits { get; set; }
-
-        public int TotalAdditions { get; set; }
-
-        public int TotalDeletions { get; set; }
-
-        public GitHubCachedGlobalContributorModel() { }
-
-        public GitHubCachedGlobalContributorModel(GitHubGlobalContributorModel contributor)
-        {
-            AuthorId = contributor.Author.Id;
-            AuthorLogin = contributor.Author.Login;
-            AuthorUrl = contributor.Author.HtmlUrl;
-            AuthorAvatarUrl = contributor.Author.AvatarUrl;
-            TotalCommits = contributor.TotalCommits;
-            TotalAdditions = contributor.TotalAdditions;
-            TotalDeletions = contributor.TotalDeletions;
-        }
-
-    }
-
     public class GitHubGlobalContributorModel
     {
         public List<GitHubContributorModel> Items { get; set; }

--- a/OurUmbraco/Community/GitHub/Models/GitHubGlobalContributorModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/GitHubGlobalContributorModel.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
-using OurUmbraco.Community.Models;
 
-namespace OurUmbraco.Community.Controllers
+namespace OurUmbraco.Community.GitHub.Models
 {
 
     public class GitHubCachedGlobalContributorModel

--- a/OurUmbraco/Community/GitHub/Models/GithubContributorModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/GithubContributorModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace OurUmbraco.Community.Models
+namespace OurUmbraco.Community.GitHub.Models
 {
     [DataContract]
     public class GitHubContributorModel : IGitHubContributorModel

--- a/OurUmbraco/Community/GitHub/Models/IGitHubContributorModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/IGitHubContributorModel.cs
@@ -1,4 +1,4 @@
-﻿namespace OurUmbraco.Community.Models
+﻿namespace OurUmbraco.Community.GitHub.Models
 {
     public interface IGitHubContributorModel
     {

--- a/OurUmbraco/Community/GitHub/Models/IGitHubContributorsModel.cs
+++ b/OurUmbraco/Community/GitHub/Models/IGitHubContributorsModel.cs
@@ -1,4 +1,4 @@
-﻿namespace OurUmbraco.Community.Models
+﻿namespace OurUmbraco.Community.GitHub.Models
 {
     public interface IGitHubContributorsModel
     {

--- a/OurUmbraco/NotificationsCore/Notifications/ScheduleHangfireJobs.cs
+++ b/OurUmbraco/NotificationsCore/Notifications/ScheduleHangfireJobs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Hangfire;
+using OurUmbraco.Community.GitHub;
 using Umbraco.Core;
 using Umbraco.Core.Persistence;
 
@@ -28,6 +29,23 @@ namespace OurUmbraco.NotificationsCore.Notifications
                 }
             }
         }
+
+        public void UpdateGitHubContributors()
+        {
+            RecurringJob.AddOrUpdate(() => UpdateGitHubContributorsJsonFile(), Cron.Daily);
+        }
+
+        public void UpdateGitHubContributorsJsonFile()
+        {
+
+            // Initialize a new service
+            GitHubService service = new GitHubService();
+
+            // Determine the path to the JSON file
+            service.UpdateOverallContributors();
+
+        }
+    
     }
 
     public class ReminderTopic

--- a/OurUmbraco/Our/GoogleOAuth/UmbracoStandardOwinStartup.cs
+++ b/OurUmbraco/Our/GoogleOAuth/UmbracoStandardOwinStartup.cs
@@ -43,6 +43,7 @@ namespace OurUmbraco.Our.GoogleOAuth
             // Schedule jobs
             var scheduler = new ScheduleHangfireJobs();
             scheduler.MarkAsSolvedReminder();
+            scheduler.UpdateGitHubContributors();
         }
     }
 }

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -527,7 +527,7 @@
     <Compile Include="NotificationsWeb\Services\NotificationService.cs" />
     <Compile Include="NotificationsWeb\Singleton.cs" />
     <Compile Include="Our\Api\CommunityController.cs" />
-    <Compile Include="Community\GitHub\GitHubRepository.cs" />
+    <Compile Include="Community\GitHub\GitHubService.cs" />
     <Compile Include="Our\Api\SearchController.cs" />
     <Compile Include="Our\Api\YouTrackApiController.cs" />
     <Compile Include="Our\Businesslogic\ProjectContributor.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -526,7 +526,7 @@
     <Compile Include="NotificationsWeb\Services\NotificationService.cs" />
     <Compile Include="NotificationsWeb\Singleton.cs" />
     <Compile Include="Our\Api\CommunityController.cs" />
-    <Compile Include="Our\Api\GitHubController.cs" />
+    <Compile Include="Community\GitHub\GitHubRepository.cs" />
     <Compile Include="Our\Api\SearchController.cs" />
     <Compile Include="Our\Api\YouTrackApiController.cs" />
     <Compile Include="Our\Businesslogic\ProjectContributor.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -410,6 +410,7 @@
     <Compile Include="Community\Controllers\TwitterSearchController.cs" />
     <Compile Include="Community\GitHub\Models\GitHubContributorModel.cs" />
     <Compile Include="Community\GitHub\Models\IGitHubContributorModel.cs" />
+    <Compile Include="Community\GitHub\Models\GitHubContributorsResult.cs" />
     <Compile Include="Community\Models\MeetupEventsModel.cs" />
     <Compile Include="Community\Models\MeetupItem.cs" />
     <Compile Include="Community\GitHub\Models\GitHubContributorsModel.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -403,16 +403,16 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CamelCaseFormatter.cs" />
-    <Compile Include="Community\Controllers\GitHubContributorController.cs" />
+    <Compile Include="Community\GitHub\Controllers\GitHubContributorController.cs" />
     <Compile Include="Community\Controllers\MeetupsController.cs" />
-    <Compile Include="Community\Controllers\GitHubGlobalContributorModel.cs" />
+    <Compile Include="Community\GitHub\Models\GitHubGlobalContributorModel.cs" />
     <Compile Include="Community\Controllers\TwitterSearchController.cs" />
-    <Compile Include="Community\Models\GitHubContributorModel.cs" />
-    <Compile Include="Community\Models\IGitHubContributorModel.cs" />
+    <Compile Include="Community\GitHub\Models\GitHubContributorModel.cs" />
+    <Compile Include="Community\GitHub\Models\IGitHubContributorModel.cs" />
     <Compile Include="Community\Models\MeetupEventsModel.cs" />
     <Compile Include="Community\Models\MeetupItem.cs" />
-    <Compile Include="Community\Models\GitHubContributorsModel.cs" />
-    <Compile Include="Community\Models\IGitHubContributorsModel.cs" />
+    <Compile Include="Community\GitHub\Models\GitHubContributorsModel.cs" />
+    <Compile Include="Community\GitHub\Models\IGitHubContributorsModel.cs" />
     <Compile Include="Community\Models\TweetsModel.cs" />
     <Compile Include="CustomDateTimeConvertor.cs" />
     <Compile Include="Documentation\Busineslogic\ConventionExtensions.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -405,6 +405,7 @@
     <Compile Include="CamelCaseFormatter.cs" />
     <Compile Include="Community\GitHub\Controllers\GitHubContributorController.cs" />
     <Compile Include="Community\Controllers\MeetupsController.cs" />
+    <Compile Include="Community\GitHub\Models\Cached\GitHubCachedGlobalContributorModel.cs" />
     <Compile Include="Community\GitHub\Models\GitHubGlobalContributorModel.cs" />
     <Compile Include="Community\Controllers\TwitterSearchController.cs" />
     <Compile Include="Community\GitHub\Models\GitHubContributorModel.cs" />


### PR DESCRIPTION
This is still work in progress, so it's just to put it up here for any comments.

I haven't yet had the time to test the new logic that thoroughly when integrated with Our Umbraco, but the `GitHubService` class seems to work like it should. I will do some more testing, but you can now get the overall list of contributors like this (the parameter is the amount of retries, where `3` seems to be a fitting number):

```C#
GitHubService service = new GitHubService();
GitHubContributorsResult result = service.GetOverallContributors(3);
```

The `GetOverallContributors` also sorts the contributors a bit better - eg. if two users have the same amount of commits, but one has more additions than the other. So the one with the highest amount of additions is shown first. I'm also sorting by deletions should two users have the exact same amount of commits and additions - even though that is probably an edge case.

The actual view showing the contributors is calling the `GitHubContributorController` surface controller. I haven't updated this with the new logic yet, but that's probably the next thing I'm going to work on.

Since we want to update the contributors in the background, I've configured a Hangfire recurring job to call the `UpdateOverallContributors` method once a day.  The logic for updating the JSON is isolated in it's own method in the service class so it can be called from where we want to - eg. if we have to force an update of the JSON file, we can have the surface controller call the method directly, so we don't have to wait for the Hangfire job to run.

I should have some time over the weekend to finish the pull request ;)