### PR TITLE
Optimize github contributors for different breakpoints on frontpage

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_contributors.scss
+++ b/OurUmbraco.Client/src/scss/sections/_contributors.scss
@@ -1,10 +1,7 @@
-﻿#github-contributors {
-
-    small.link-list {
-        font-style: italic;
-        font-weight: normal;
-        text-transform: none;
-    }
+﻿small.github-repo-list {
+    font-style: italic;
+    font-weight: normal !important;
+    text-transform: none !important;
 }
 
 .github-contributor-list {

--- a/OurUmbraco.Client/src/scss/sections/_contributors.scss
+++ b/OurUmbraco.Client/src/scss/sections/_contributors.scss
@@ -1,21 +1,52 @@
 ﻿#github-contributors {
+
+    small.link-list {
+        font-style: italic;
+        font-weight: normal;
+        text-transform: none;
+    }
+}
+
+.github-contributor-list {
+    justify-content: center !important;
     &:not(.all) {
         .contributor {
-            &:nth-child(n+17) {
-                display: none;
+            
+            /* Hide element no. 9 and above (2 items per row) */
+            @media (max-width: 440px) {
+                &:nth-child(n+9) {
+                    display: none;
+                }
             }
 
-            @media (max-width: $md) {
+            /* Hide element no. 10 and above (3 items per row) */
+            @media (min-width: 440px) and (max-width: 580px) {
+                &:nth-child(n+10) {
+                    display: none;
+                }
+            }
+
+            /* Hide element no. 13 and above (4 items per row) */
+            @media (min-width: 580px) and (max-width: 680px) {
                 &:nth-child(n+13) {
                     display: none;
                 }
             }
 
-            @media (max-width: $xs) {
-                &:nth-child(n+10) {
+            /* Hide element no. 16 and above (5 items per row) */
+            @media (min-width: 580px) and (max-width: $md) {
+                &:nth-child(n+16) {
                     display: none;
                 }
             }
+
+            /* Hide element no. 17 and above (8 items per row) */
+            @media (min-width: $md) {
+                &:nth-child(n+17) {
+                    display: none;
+                }
+            }
+
         }
     }
 
@@ -32,22 +63,46 @@
     }
 }
 
-.github-contributors small.link-list {
-    font-style: italic;
-    font-weight: normal;
-    text-transform: none;
-}
-
 .contributor {
+    display: flex;
+    flex-wrap: wrap;
+    flex: 0 0 50%;
+    padding: 5px;
     margin-bottom: 15px;
 
+    /* 3 items per row */
+    @media (min-width: 440px) {
+        flex: 0 0 33.3333%;
+    }
+
+    /* 4 items per row */
+    @media (min-width: 580px) {
+        flex: 0 0 25%;
+    }
+
+    /* 5 items per row */
+    @media (min-width: 680px) {
+        flex: 0 0 20%;
+    }
+
+    /* 8 items per row */
+    @media (min-width: $md) {
+        flex: 0 0 12.5%;
+    }
+
+    > a {
+        display: inline-block;
+        margin: 0 auto;
+    }
+
     .avatar {
+        display: inline-block;
         position: relative;
-        flex: 0 0 23%;
-        margin-right: 20px;
+        flex: 0 0 auto !important;
+        margin: 0 auto !important;
 
         @media (min-width: $md) {
-            flex: 0 0 15%;
+            flex: 0 0 auto !important;
         }
 
         img {
@@ -59,6 +114,9 @@
     }
 
     .counts {
+        display: flex;
+        flex-flow: column wrap;
+        justify-content: center;
         position: absolute;
         top: 2px;
         left: 2px;
@@ -70,9 +128,13 @@
         background: rgba(0,0,0,0.25);
         border-radius: 50%;
         bottom: 6px;
-        padding-top: 23px;
+        padding: 0;
         opacity: 0;
         transition: opacity 0.25s;
+        > div {
+            margin-top: 5px;
+            margin-bottom: 5px;
+        }
     }
 
     &:hover .counts {

--- a/OurUmbraco.Client/src/scss/sections/_contributors.scss
+++ b/OurUmbraco.Client/src/scss/sections/_contributors.scss
@@ -1,7 +1,9 @@
-﻿small.github-repo-list {
-    font-style: italic;
-    font-weight: normal !important;
-    text-transform: none !important;
+﻿.github-contributions {
+    small.github-repo-list {
+        font-style: italic;
+        font-weight: normal;
+        text-transform: none;
+    }
 }
 
 .github-contributor-list {

--- a/OurUmbraco.Client/src/scss/sections/_contributors.scss
+++ b/OurUmbraco.Client/src/scss/sections/_contributors.scss
@@ -105,7 +105,7 @@
         }
 
         img {
-            border: 3px solid #98d768;
+            border: 3px solid $color-our;
             width: 100%;
             max-width: 112px;
             height: auto;
@@ -146,9 +146,9 @@
         bottom: 0px;
         text-align: center;
         right: 25px;
-        color: #425a2e;
+        color: darken($color-our, 40%);
         font-weight: bold;
-        background: darken($color-our, 4%);
+        background: $color-our;
         border-radius: 15px;
         z-index: 5;
     }

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -99,12 +99,12 @@
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ImageProcessor, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.2.5.2\lib\net45\ImageProcessor.dll</HintPath>
+    <Reference Include="ImageProcessor, Version=2.5.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.2.5.4\lib\net45\ImageProcessor.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ImageProcessor.Web, Version=4.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.Web.4.8.2\lib\net45\ImageProcessor.Web.dll</HintPath>
+    <Reference Include="ImageProcessor.Web, Version=4.8.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.Web.4.8.4\lib\net45\ImageProcessor.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="interfaces, Version=1.0.6274.27351, Culture=neutral, processorArchitecture=MSIL">
@@ -148,8 +148,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.1\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
+    <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.2\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -140,7 +140,7 @@ else
                 <div class="col-md-12">
                     <h1 class="text-center">GitHub Contributions</h1>
                     <p>
-                        <small class="link-list">
+                        <small class="github-repo-list">
                             Contributions to default branches for
                             <a href="https://github.com/umbraco/Umbraco-CMS" target="_blank" title="Umbraco-CMS">Umbraco-CMS</a>,
                             <a href="https://github.com/umbraco/UmbracoDocs" target="_blank" title="UmbracoDocs">UmbracoDocs</a>,

--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -134,7 +134,7 @@ else
 
 @helper  GitHubContributors()
 {
-    <section class="forum">
+    <section class="forum github-contributions">
         <div class="container">
             <div class="row">
                 <div class="col-md-12">

--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -134,7 +134,7 @@ else
 
 @helper  GitHubContributors()
 {
-    <section class="github-contributors forum">
+    <section class="forum">
         <div class="container">
             <div class="row">
                 <div class="col-md-12">
@@ -155,7 +155,7 @@ else
                     <small>Contributions the last 12 months (number indicating accepted commits)</small>
                 </div>
 
-                <div class="col-md-12 flex forum-thread" id="github-contributors">
+                <div class="col-md-12 flex" id="github-contributors">
                     <h2>Loading GitHub contributors...</h2>
                 </div>
 
@@ -168,7 +168,8 @@ else
     </section>
 }
 
-@helper Meetups() {   
+@helper Meetups()
+{   
     <section class="forum">
         <div class="container">
             <div class="row">

--- a/OurUmbraco.Site/Views/Partials/Community/Scripts.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Scripts.cshtml
@@ -1,8 +1,7 @@
 ﻿<script type="text/javascript">
 
     function loadAllGitHubContributors() {
-        $('#github-contributors').addClass('all');
-
+        $('#github-contributors .github-contributor-list').addClass('all');
     }
 
     $(document).ready(function() {
@@ -13,9 +12,7 @@
         }
 
         try {
-            console.log("@Url.Action("GetEvents", "Meetups")");
             $("#meetups").load("@Url.Action("GetEvents", "Meetups")");
-            console.log('yay');
         }
         catch (errTwitter) {
             console.log("Couldn't load meetups", errTwitter.message);

--- a/OurUmbraco.Site/Views/Partials/Home/GitHubContributors.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Home/GitHubContributors.cshtml
@@ -8,8 +8,8 @@
             <div class="contributor">
                 <a href="@contributor.AuthorUrl" target="_blank" title="@contributor.AuthorLogin">
                     <div class="avatar">
-                        <img alt="@contributor.AuthorLogin" width="112" height="112" src="@contributor.AuthorAvatarUrl&s=112"
-                             srcset="@contributor.AuthorAvatarUrl&s=224 2x, @contributor.AuthorAvatarUrl&s=336 3x" />
+                        <img alt="@contributor.AuthorLogin" src="@GetAvatarUrl(contributor.AuthorAvatarUrl, 112)"
+                             srcset="@GetAvatarUrl(contributor.AuthorAvatarUrl, 224) 2x,@GetAvatarUrl(contributor.AuthorAvatarUrl, 336) 3x" />
                         <span class="contrib-count" title="@(contributor.TotalCommits + " " + (contributor.TotalCommits == 1 ? "contribution" : "contributions"))">
                             @contributor.TotalCommits
                         </span>
@@ -35,4 +35,16 @@
 else
 {
     <h2>Could not load recent GitHub contributors.</h2>
+}
+
+@functions
+{
+    private string GetAvatarUrl(string url, int size)
+    {
+        if (string.IsNullOrEmpty(url))
+            return string.Empty;
+
+        string host = url.TrimStart("http://").TrimStart("https://");
+        return string.Format("/remote.axd/{0}?width={1}&upscale=true", host,  size);
+    }
 }

--- a/OurUmbraco.Site/Views/Partials/Home/GitHubContributors.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Home/GitHubContributors.cshtml
@@ -2,27 +2,33 @@
 
 @if (Model.Contributors.Any())
 {
-    foreach (var contributor in Model.Contributors)
-    {
-            <a href="@contributor.AuthorUrl" class="contributor" target="_blank" title="@contributor.AuthorLogin">
-                <div class="avatar">
-                    <img alt="@contributor.AuthorLogin" src="@contributor.AuthorAvatarUrl&s=112"
-                         srcset="@contributor.AuthorAvatarUrl&s=224 2x, @contributor.AuthorAvatarUrl&s=336 3x" />
-                    <span class="contrib-count" title="@(contributor.TotalCommits + " " + (contributor.TotalCommits == 1 ? "contribution" : "contributions"))">
-                        @contributor.TotalCommits
-                    </span>
-                    <div class="counts">
-                        Additions<br />
-                        <strong>@contributor.TotalAdditions</strong><br />
-                        <br />
-                        Deletions<br />
-                        <strong>@contributor.TotalDeletions</strong>
+    <div class="flex flex-wrap github-contributor-list forum-thread">
+        @foreach (var contributor in Model.Contributors)
+        {
+            <div class="contributor">
+                <a href="@contributor.AuthorUrl" target="_blank" title="@contributor.AuthorLogin">
+                    <div class="avatar">
+                        <img alt="@contributor.AuthorLogin" width="112" height="112" src="@contributor.AuthorAvatarUrl&s=112"
+                             srcset="@contributor.AuthorAvatarUrl&s=224 2x, @contributor.AuthorAvatarUrl&s=336 3x" />
+                        <span class="contrib-count" title="@(contributor.TotalCommits + " " + (contributor.TotalCommits == 1 ? "contribution" : "contributions"))">
+                            @contributor.TotalCommits
+                        </span>
+                        <div class="counts">
+                            <div>Additions<br />
+                                <strong>@contributor.TotalAdditions</strong>
+                            </div>
+                            <div>Deletions<br />
+                                <strong>@contributor.TotalDeletions</strong>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </a>
-    }
-    <div class="loadmore">
-        <a class="button transparent" href="#" onclick="loadAllGitHubContributors(); return false;">Load more</a>
+                </a>
+            </div>
+        }
+
+        <div class="loadmore">
+            <a class="button transparent" href="#" onclick="loadAllGitHubContributors(); return false;">Load more</a>
+        </div>
     </div>
 }
 

--- a/OurUmbraco.Site/config/imageprocessor/security.config
+++ b/OurUmbraco.Site/config/imageprocessor/security.config
@@ -23,6 +23,7 @@
         <add url="https://avatars1.githubusercontent.com" />
         <add url="https://avatars2.githubusercontent.com" />
         <add url="https://avatars3.githubusercontent.com" />
+        <add url="https://avatars4.githubusercontent.com" />
       </whitelist>
     </service>
   </services>

--- a/OurUmbraco.Site/config/imageprocessor/security.config
+++ b/OurUmbraco.Site/config/imageprocessor/security.config
@@ -24,6 +24,9 @@
         <add url="https://avatars2.githubusercontent.com" />
         <add url="https://avatars3.githubusercontent.com" />
         <add url="https://avatars4.githubusercontent.com" />
+        <add url="https://avatars5.githubusercontent.com" />
+        <add url="https://avatars6.githubusercontent.com" />
+        <add url="https://avatars7.githubusercontent.com" />
       </whitelist>
     </service>
   </services>

--- a/OurUmbraco.Site/config/imageprocessor/security.config
+++ b/OurUmbraco.Site/config/imageprocessor/security.config
@@ -16,8 +16,13 @@
         <setting key="MaxBytes" value="4194304" />
         <setting key="Timeout" value="3000" />
         <setting key="Protocol" value="http" />
+        <setting key="Useragent" value="Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"/>
       </settings>
       <whitelist>
+        <add url="https://avatars0.githubusercontent.com" />
+        <add url="https://avatars1.githubusercontent.com" />
+        <add url="https://avatars2.githubusercontent.com" />
+        <add url="https://avatars3.githubusercontent.com" />
       </whitelist>
     </service>
   </services>

--- a/OurUmbraco.Site/packages.config
+++ b/OurUmbraco.Site/packages.config
@@ -9,8 +9,8 @@
   <package id="EasyHttp" version="1.6.29.0" targetFramework="net451" />
   <package id="Examine" version="0.1.81" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
-  <package id="ImageProcessor" version="2.5.2" targetFramework="net452" />
-  <package id="ImageProcessor.Web" version="4.8.2" targetFramework="net452" />
+  <package id="ImageProcessor" version="2.5.4" targetFramework="net452" />
+  <package id="ImageProcessor.Web" version="4.8.4" targetFramework="net452" />
   <package id="ImageProcessor.Web.Config" version="2.3.0.0" targetFramework="net452" />
   <package id="jQuery" version="1.4.1" targetFramework="net451" />
   <package id="jQuery.Validation" version="1.8" targetFramework="net451" />
@@ -38,7 +38,7 @@
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.1" targetFramework="net452" />
+  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.2" targetFramework="net452" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.20710.0" targetFramework="net451" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -93,12 +93,12 @@
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ImageProcessor, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.2.5.2\lib\net45\ImageProcessor.dll</HintPath>
+    <Reference Include="ImageProcessor, Version=2.5.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.2.5.4\lib\net45\ImageProcessor.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ImageProcessor.Web, Version=4.8.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.Web.4.8.2\lib\net45\ImageProcessor.Web.dll</HintPath>
+    <Reference Include="ImageProcessor.Web, Version=4.8.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.Web.4.8.4\lib\net45\ImageProcessor.Web.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="interfaces, Version=1.0.6261.14289, Culture=neutral, processorArchitecture=MSIL">
@@ -169,8 +169,8 @@
       <HintPath>..\packages\Microsoft.Extensions.Primitives.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.1\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
+    <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.2.2\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/OurUmbraco/packages.config
+++ b/OurUmbraco/packages.config
@@ -10,8 +10,8 @@
   <package id="Hangfire.Core" version="1.6.8" targetFramework="net452" />
   <package id="Hangfire.SqlServer" version="1.6.8" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
-  <package id="ImageProcessor" version="2.5.2" targetFramework="net452" />
-  <package id="ImageProcessor.Web" version="4.8.2" targetFramework="net452" />
+  <package id="ImageProcessor" version="2.5.4" targetFramework="net452" />
+  <package id="ImageProcessor.Web" version="4.8.4" targetFramework="net452" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net451" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net452" />
   <package id="Markdown" version="1.14.7" targetFramework="net452" />
@@ -36,7 +36,7 @@
   <package id="Microsoft.Extensions.FileProviders.Physical" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.1" targetFramework="net452" />
+  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.2.2" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />


### PR DESCRIPTION
Issue: http://issues.umbraco.org/issue/OUR-462

I have optimized the number of github contributors per row depending on different breakpoints.
Furthermore the white background is also aligned vertically with the other in e.g. forum posts and center the avatars, which I think look better e.g. when there is only two elements on last row.

**Before**
![image](https://user-images.githubusercontent.com/2919859/28171555-1974b866-67e9-11e7-9a5f-0f8ad0e0a252.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/28172171-2258d082-67eb-11e7-993b-7d285fd11bce.png)

**Before**
![image](https://user-images.githubusercontent.com/2919859/28172572-34d952c6-67ec-11e7-87ec-4653c65e5856.png)

**After**
![image](https://user-images.githubusercontent.com/2919859/28172594-47363fba-67ec-11e7-8400-2720f58cb3fa.png)


It also fix these issues on mobile.
Same width of the white background as for forum posts, meetups etc.
![screenshot_20170713-170647](https://user-images.githubusercontent.com/2919859/28173347-777e3324-67ee-11e7-8981-1f31fc6cb73b.png)

Init number of github contributors fit to fill the row.
![screenshot_20170713-170658](https://user-images.githubusercontent.com/2919859/28173363-86e204ee-67ee-11e7-835d-8e03f38f8b24.png)

The smaller avatar in screenshot above is because the original image is too small for retina screens - the original size is only 200x200px https://avatars3.githubusercontent.com/u/1769475
Alternatively it can use ImageProcessor to handle size of the image, which allow upscale and allow remote domains like https://avatars3.githubusercontent.com

I think the  avatars can have image urls from avatars1.githubusercontent.com , avatars2.githubusercontent.com and avatars3.githubusercontent.com ... not sure if there are more.