### PR TITLE
OUR-464: Master badges on Our profiles

### DIFF
--- a/OurUmbraco.Client/src/scss/core/_helpers.scss
+++ b/OurUmbraco.Client/src/scss/core/_helpers.scss
@@ -27,7 +27,7 @@
 	$color-roles-purple: #df89ff;
 	$color-roles-orange: #e8b142;
 	$color-roles-blue:	 #5dacff;
-    $color-roles-indigo: #5d00a2;
+	$color-roles-indigo: #5d00a2;
 
 	$color-headline: 	 rgba(#000, .8);
 	$color-text: 		 rgba(#000, 1);

--- a/OurUmbraco.Client/src/scss/core/_helpers.scss
+++ b/OurUmbraco.Client/src/scss/core/_helpers.scss
@@ -27,6 +27,7 @@
 	$color-roles-purple: #df89ff;
 	$color-roles-orange: #e8b142;
 	$color-roles-blue:	 #5dacff;
+    $color-roles-indigo: #5d00a2;
 
 	$color-headline: 	 rgba(#000, .8);
 	$color-text: 		 rgba(#000, 1);

--- a/OurUmbraco.Client/src/scss/elements/_roles.scss
+++ b/OurUmbraco.Client/src/scss/elements/_roles.scss
@@ -99,5 +99,15 @@
 				padding: inherit;
 			}
 		}
+
+		&.master {
+			border-color: $color-roles-indigo;
+			color: $color-roles-indigo;
+			text-transform: capitalize;
+
+			// &:hover {
+			// 	background-color: rgba($color-roles-indigo, .1);
+			// }
+		}
 	}
 }

--- a/OurUmbraco/Forum/Extensions/ForumExtensions.cs
+++ b/OurUmbraco/Forum/Extensions/ForumExtensions.cs
@@ -183,6 +183,12 @@ namespace OurUmbraco.Forum.Extensions
                     continue;
                 }
 
+                if (role == "Master")
+                {
+                    memberRoles.Add("master");
+                    continue;
+                }
+
                 memberRoles.Add(role.ToLower());
             }
 

--- a/OurUmbraco/Our/Api/BadgesController.cs
+++ b/OurUmbraco/Our/Api/BadgesController.cs
@@ -18,6 +18,7 @@ namespace OurUmbraco.Our.Api
         }
 
         [HttpPost]
+        [VerifyTokenHeader("BadgesApiToken")]
         public string AwardMasterBadge(string email)
         {
             var member = MemberService.GetByEmail(email);

--- a/OurUmbraco/Our/Api/BadgesController.cs
+++ b/OurUmbraco/Our/Api/BadgesController.cs
@@ -46,28 +46,46 @@ namespace OurUmbraco.Our.Api
             return "Failed to assign c-trib status";
         }
 
-        private bool AwardBadge(IMember member, string roleName, string karmaRewardAppSetting)
+        /// <summary>
+        /// Assigns a badge to a given member and awards karma points
+        /// </summary>
+        /// <param name="member">The member</param>
+        /// <param name="badgeName">The name of the member group (badge) to assign to the member</param>
+        /// <param name="karmaRewardKey">The appSettings key for the amount of karma points to reward the member</param>
+        /// <returns></returns>
+        private bool AwardBadge(IMember member, string badgeName, string karmaRewardKey)
         {
-            var karmaPoints = Convert.ToInt32(ConfigurationManager.AppSettings[karmaRewardAppSetting]);
+            var karmaPoints = Convert.ToInt32(ConfigurationManager.AppSettings[karmaRewardKey]);
 
-            return AwardBadge(member, roleName, karmaPoints);
+            return AwardBadge(member, badgeName, karmaPoints);
         }
 
-        private bool AwardBadge(IMember member, string roleName, int karmaReward = 0)
+        /// <summary>
+        /// Assigns a badge to a given member and awards karma points
+        /// </summary>
+        /// <param name="member">The member</param>
+        /// <param name="badgeName">The name of the member group (badge) to assign to the member</param>
+        /// <param name="karmaReward">The amount of karma points to reward the member</param>
+        /// <returns></returns>
+        private bool AwardBadge(IMember member, string badgeName, int karmaReward = 0)
         {
             if (member == null)
             {
                 return false;
             }
 
+            // get the members current badges
             var currentRoles = MemberService.GetAllRoles(member.Id);
 
-            if (!currentRoles.Contains(roleName))
+            // check the member does not have the badge yet
+            if (!currentRoles.Contains(badgeName))
             {
-                MemberService.AssignRole(member.Id, roleName);
+                // assign the badge to the member
+                MemberService.AssignRole(member.Id, badgeName);
 
                 if (karmaReward > 0)
                 {
+                    // award karma points to the member
                     member.IncreaseKarma(karmaReward);
 
                     return true;

--- a/OurUmbraco/Our/Api/BadgesController.cs
+++ b/OurUmbraco/Our/Api/BadgesController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Configuration;
+using System.Linq;
 using System.Web.Http;
 using OurUmbraco.Forum.Extensions;
 using Umbraco.Core.Models;
@@ -54,7 +55,14 @@ namespace OurUmbraco.Our.Api
 
         private bool AwardBadge(IMember member, string roleName, int karmaReward = 0)
         {
-            if (member != null)
+            if (member == null)
+            {
+                return false;
+            }
+
+            var currentRoles = MemberService.GetAllRoles(member.Id);
+
+            if (!currentRoles.Contains(roleName))
             {
                 MemberService.AssignRole(member.Id, roleName);
 

--- a/OurUmbraco/Our/Api/BadgesController.cs
+++ b/OurUmbraco/Our/Api/BadgesController.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Configuration;
+using System.Web.Http;
+using OurUmbraco.Forum.Extensions;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Web.WebApi;
+
+namespace OurUmbraco.Our.Api
+{
+    public class BadgesController : UmbracoApiController
+    {
+        private IMemberService MemberService;
+
+        public BadgesController()
+        {
+            MemberService = ApplicationContext.Services.MemberService;
+        }
+
+        [HttpPost]
+        public string AwardMasterBadge(string email)
+        {
+            var member = MemberService.GetByEmail(email);
+
+            if (AwardBadge(member, "Master", "MasterBadgeKarmaPoints"))
+            {
+                return "Member " + email + " now has master status";
+            }
+
+            return "Failed to assign master status";
+        }
+
+        private bool AwardBadge(IMember member, string roleName, string karmaRewardAppSetting)
+        {
+            var karmaPoints = Convert.ToInt32(ConfigurationManager.AppSettings[karmaRewardAppSetting]);
+
+            return AwardBadge(member, roleName, karmaPoints);
+        }
+
+        private bool AwardBadge(IMember member, string roleName, int karmaReward = 0)
+        {
+            if (member != null)
+            {
+                MemberService.AssignRole(member.Id, roleName);
+
+                if (karmaReward > 0)
+                {
+                    member.IncreaseKarma(karmaReward);
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/OurUmbraco/Our/Api/BadgesController.cs
+++ b/OurUmbraco/Our/Api/BadgesController.cs
@@ -31,6 +31,20 @@ namespace OurUmbraco.Our.Api
             return "Failed to assign master status";
         }
 
+        [HttpPost]
+        [VerifyTokenHeader("BadgesApiToken")]
+        public string AwardCoreContribBadge(string email)
+        {
+            var member = MemberService.GetByEmail(email);
+
+            if (AwardBadge(member, "CoreContrib", "CoreContribBadgeKarmaPoints"))
+            {
+                return "Member " + email + " now has c-trib status";
+            }
+
+            return "Failed to assign c-trib status";
+        }
+
         private bool AwardBadge(IMember member, string roleName, string karmaRewardAppSetting)
         {
             var karmaPoints = Convert.ToInt32(ConfigurationManager.AppSettings[karmaRewardAppSetting]);

--- a/OurUmbraco/Our/MigrationsHandler.cs
+++ b/OurUmbraco/Our/MigrationsHandler.cs
@@ -44,6 +44,7 @@ namespace OurUmbraco.Our
             AddHomeScriptsMacro();
             AddNuGetUrlForPackages();
             AddPeopleKarmaPage();
+            AddMasterMemberGroup();
         }
         
         private void EnsureMigrationsMarkerPathExists()
@@ -965,6 +966,37 @@ namespace OurUmbraco.Our
 
                 fileService.SaveTemplate(releaseCompareTemplate);
                 
+
+                string[] lines = { "" };
+                File.WriteAllLines(path, lines);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<MigrationsHandler>(string.Format("Migration: '{0}' failed", migrationName), ex);
+            }
+        }
+
+        private void AddMasterMemberGroup()
+        {
+            var migrationName = MethodBase.GetCurrentMethod().Name;
+
+            try
+            {
+                var path = HostingEnvironment.MapPath(MigrationMarkersPath + migrationName + ".txt");
+                if (File.Exists(path))
+                    return;
+
+                var memberGroupService = ApplicationContext.Current.Services.MemberGroupService;
+
+                if (memberGroupService.GetByName("Master") == null)
+                {
+                    var memberGroup = new MemberGroup()
+                    {
+                        Name = "Master"
+                    };
+
+                    memberGroupService.Save(memberGroup);
+                }
 
                 string[] lines = { "" };
                 File.WriteAllLines(path, lines);

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -528,6 +528,7 @@
     <Compile Include="Our\Api\CommunityController.cs" />
     <Compile Include="Our\Api\GitHubController.cs" />
     <Compile Include="Our\Api\SearchController.cs" />
+    <Compile Include="Our\Api\BadgesController.cs" />
     <Compile Include="Our\Api\YouTrackApiController.cs" />
     <Compile Include="Our\Businesslogic\ProjectContributor.cs" />
     <Compile Include="Our\Controllers\AvatarController.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -787,6 +787,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="UmbracoAuthorizationFilter.cs" />
+    <Compile Include="VerifyTokenHeaderAttribute.cs" />
     <Compile Include="Version\Config.cs" />
     <Compile Include="Version\uWikiFileVerison.cs" />
     <Compile Include="Wiki\Api\WikiController.cs" />

--- a/OurUmbraco/VerifyTokenHeaderAttribute.cs
+++ b/OurUmbraco/VerifyTokenHeaderAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Configuration;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+
+namespace OurUmbraco
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class VerifyTokenHeaderAttribute : AuthorizeAttribute
+    {
+        private readonly string _tokenKey;
+
+        public VerifyTokenHeaderAttribute(string tokenKey)
+        {
+            _tokenKey = tokenKey;
+        }
+
+        protected override bool IsAuthorized(HttpActionContext context)
+        {
+            var request = context.Request;
+
+            var tokenHeaders = Enumerable.Empty<string>();
+            var tokenAppSetting = ConfigurationManager.AppSettings[_tokenKey];
+
+            request.Headers.TryGetValues("token", out tokenHeaders);
+
+            if (tokenHeaders.Any() && !string.IsNullOrWhiteSpace(tokenAppSetting))
+            {
+                var header = tokenHeaders.FirstOrDefault();
+
+                if (header.Equals(_tokenKey, StringComparison.InvariantCulture))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/OurUmbraco/VerifyTokenHeaderAttribute.cs
+++ b/OurUmbraco/VerifyTokenHeaderAttribute.cs
@@ -11,6 +11,10 @@ namespace OurUmbraco
     {
         private readonly string _tokenKey;
 
+        /// <summary>
+        /// Verifies the "token" HTTP header against an appSettings value
+        /// </summary>
+        /// <param name="tokenKey">The appSettings key to verify the value of the token against</param>
         public VerifyTokenHeaderAttribute(string tokenKey)
         {
             _tokenKey = tokenKey;
@@ -23,10 +27,12 @@ namespace OurUmbraco
             var tokenHeaders = Enumerable.Empty<string>();
             var tokenAppSetting = ConfigurationManager.AppSettings[_tokenKey];
 
+            // get the token header values
             request.Headers.TryGetValues("token", out tokenHeaders);
 
             if (tokenHeaders.Any() && !string.IsNullOrWhiteSpace(tokenAppSetting))
             {
+                // get the first token header in the list
                 var header = tokenHeaders.FirstOrDefault();
 
                 if (header.Equals(_tokenKey, StringComparison.InvariantCulture))


### PR DESCRIPTION
I think it would be great for those who have achieved the "Master" status to have a badge on their Our profiles. We currently have the certification profiles on Umbraco.com but there's currently no indicator on Our right now.

This was added to the issue tracker here: http://issues.umbraco.org/issue/OUR-464

I have created a "Master" member group, along with the relevant styles to render the badge on profiles and also a migration to perform the necessary database changes.

I have also introduced a "Badges API" into the solution. The idea of this endpoint is to remove the need for manually assigning badges to Our profiles. Right now the API is setup to handle "Master" and "c-trib" badges, but the code has been written so this can easily be extended to more. Within the API you are also able to assign karma points to the member.

The API endpoints require a pre-shared token to be sent as the "token" header, which is to be matched against a value in appSettings. I couldn't find how to create new appSettings in the project, the following would need creating:

- "BadgesApiToken" <- the key sent in the "token" header to authenticate against, should be kept secret
- "CoreContribBadgeKarmaPoints" <- the number of karma points to be given when the "c-trib" badge is earned
- "MasterBadgeKarmaPoints" <- the number of karma points to be given when the "c-trib" badge is earned