### PR TITLE
- removed h3 font-weight 100 style on desktop

### DIFF
--- a/OurUmbraco.Client/src/scss/pages/_forum.scss
+++ b/OurUmbraco.Client/src/scss/pages/_forum.scss
@@ -179,10 +179,6 @@
 
 
 				@media (min-width: $md) {
-					h3 {
-						font-weight: 100;
-					}
-
 					span {
 						font-size: .9rem;
 					}


### PR DESCRIPTION
Problem.
On the forum page, when viewing above min width, the h3 font goes blurry because the font weight is set at 100. But if you remove this rule it looks great at the other rule where it is set at 600. You can see this on the smaller width. 

Solution
I have removed the rule which changes the font-weight for the h3 to 100.
This allows it to be styled with font-weight 600 which looks so much better.