### PR TITLE
Popular packages calculation updates

### DIFF
--- a/OurUmbraco/Our/CustomHandlers/ProjectIndexer.cs
+++ b/OurUmbraco/Our/CustomHandlers/ProjectIndexer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Examine;
 using Examine.LuceneEngine;
@@ -66,10 +67,13 @@ namespace OurUmbraco.Our.CustomHandlers
             var projectVotes = Utils.GetProjectTotalVotes(content.Id);
             var files = WikiFile.CurrentFiles(content.Id).ToArray();
             var compatVersions = Utils.GetProjectCompatibleVersions(content.Id) ?? new List<string>();
+            var downloadStats = WikiFile.GetMonthlyDownloadStatsByProject(
+                content.Id,
+                DateTime.Now.Subtract(TimeSpan.FromDays(365)));
 
             var simpleDataIndexer = (SimpleDataIndexer)ExamineManager.Instance.IndexProviderCollection["projectIndexer"];
             simpleDataSet = ((ProjectNodeIndexDataService)simpleDataIndexer.DataService)
-                .MapProjectToSimpleDataIndexItem(content, simpleDataSet, "project", projectVotes, files, downloads, compatVersions);
+                .MapProjectToSimpleDataIndexItem(downloadStats, DateTime.Now, content, simpleDataSet, "project", projectVotes, files, downloads, compatVersions);
 
             if (simpleDataSet.NodeDefinition.Type == null)
                 simpleDataSet.NodeDefinition.Type = "project";

--- a/OurUmbraco/Our/Examine/DateRangeSearchFilter.cs
+++ b/OurUmbraco/Our/Examine/DateRangeSearchFilter.cs
@@ -1,17 +1,18 @@
-﻿using Lucene.Net.Search;
-using Lucene.Net.Search.Payloads;
+﻿using System;
+using Lucene.Net.Documents;
+using Lucene.Net.Search;
 
 namespace OurUmbraco.Our.Examine
 {
-    public class RangeSearchFilter : SearchFilter
+    public class DateRangeSearchFilter : SearchFilter
     {
         private readonly float? _boost;
-        public long To { get; private set; }
+        public DateTime To { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:System.Object"/> class.
         /// </summary>
-        public RangeSearchFilter(string fieldName, long from, long to, float? boost = null) : base(fieldName, from)
+        public DateRangeSearchFilter(string fieldName, DateTime from, DateTime to, float? boost = null) : base(fieldName, from)
         {
             _boost = boost;
             To = to;
@@ -33,7 +34,7 @@ namespace OurUmbraco.Our.Examine
         /// <returns></returns>
         public override Query GetLuceneQuery()
         {
-            var query =  NumericRangeQuery.NewLongRange(FieldName, (long)Value, To, true, true);
+            var query = new TermRangeQuery(FieldName, DateTools.DateToString((DateTime)Value, DateTools.Resolution.MILLISECOND), DateTools.DateToString(To, DateTools.Resolution.MILLISECOND), true, true);
             if (_boost.HasValue)
             {
                 query.SetBoost(_boost.Value);

--- a/OurUmbraco/Our/Examine/OurSearcher.cs
+++ b/OurUmbraco/Our/Examine/OurSearcher.cs
@@ -24,7 +24,10 @@ namespace OurUmbraco.Our.Examine
         public int MaxResults { get; set; }
         public IEnumerable<SearchFilters> Filters { get; set; }
         
-        public OurSearcher(string term, string nodeTypeAlias = null, string orderBy = null, int maxResults = 20, IEnumerable<SearchFilters> filters = null)
+        public OurSearcher(string term, string nodeTypeAlias = null, 
+            string orderBy = null, 
+            int maxResults = 20, 
+            IEnumerable<SearchFilters> filters = null)
         {
             Term = term.MakeSearchQuerySafe();
             NodeTypeAlias = nodeTypeAlias;

--- a/OurUmbraco/Our/Examine/ProjectNodeIndexDataService.cs
+++ b/OurUmbraco/Our/Examine/ProjectNodeIndexDataService.cs
@@ -11,6 +11,7 @@ using Lucene.Net.Documents;
 using OurUmbraco.Project;
 using OurUmbraco.Repository.Services;
 using OurUmbraco.Wiki.BusinessLogic;
+using OurUmbraco.Wiki.Models;
 using umbraco;
 using Umbraco.Core;
 using Umbraco.Core.Configuration;
@@ -24,128 +25,16 @@ using Umbraco.Web.Security;
 namespace OurUmbraco.Our.Examine
 {
     /// <summary>
-    /// Used to calculate popularity
-    /// </summary>
-    /// <remarks>
-    /// This is a struct because it's a tiny object that we don't want hanging around in memory and is created for every project.
-    /// </remarks>
-    public struct ProjectPopularityPoints
-    {
-        public ProjectPopularityPoints(DateTime createDate, DateTime updateDate, bool worksOnCloud, bool hasForum, bool hasSourceCodeLink, bool openForCollab, int downloads, int votes)
-        {
-            _createDate = createDate;
-            _updateDate = updateDate;
-            _worksOnCloud = worksOnCloud;
-            _hasForum = hasForum;
-            _hasSourceCodeLink = hasSourceCodeLink;
-            _openForCollab = openForCollab;
-            _downloads = downloads;
-            _votes = votes;
-        }
-
-        private readonly DateTime _createDate;
-        private readonly DateTime _updateDate;
-        private readonly bool _worksOnCloud;
-        private readonly bool _hasForum;
-        private readonly bool _hasSourceCodeLink;
-        private readonly bool _openForCollab;
-        private readonly int _downloads;
-        private readonly int _votes;
-
-        public DateTime CreateDate
-        {
-            get { return _createDate; }
-        }
-
-        public DateTime UpdateDate
-        {
-            get { return _updateDate; }
-        }
-
-        public bool WorksOnCloud
-        {
-            get { return _worksOnCloud; }
-        }
-
-        public bool HasForum
-        {
-            get { return _hasForum; }
-        }
-
-        public bool HasSourceCodeLink
-        {
-            get { return _hasSourceCodeLink; }
-        }
-
-        public bool OpenForCollab
-        {
-            get { return _openForCollab; }
-        }
-
-        public int Downloads
-        {
-            get { return _downloads; }
-        }
-
-        public int Votes
-        {
-            get { return _votes; }
-        }
-
-        private int GetUpdateDateScore()
-        {
-            //sort of an exponential calculation on recent update date
-            var now = DateTime.Now;
-            var days = (now - UpdateDate).TotalDays;
-            if (days <= 30) return 5;
-            if (days <= 60) return 4;
-            if (days <= 120) return 3;
-            if (days <= 355) return 2;
-            if (days <= 700) return 1;
-            return 0;
-        }
-
-        public int Calculate()
-        {
-            //Each factor is rated (on various scales), then we can boost each factor accordingly
-            //the boost factor is the first value
-            var ranking = new List<KeyValuePair<int, int>>
-            {
-                //package downloads
-                new KeyValuePair<int, int>(1, Downloads),
-                //votes
-                new KeyValuePair<int, int>(100, Votes),
-                // - recently updated            
-                new KeyValuePair<int, int>(100, GetUpdateDateScore()),
-                // - works on Cloud
-                new KeyValuePair<int, int>(500, WorksOnCloud ? 1 : 0),
-                // - has a forum
-                new KeyValuePair<int, int>(500, HasForum ? 1 : 0),
-                // - has source code link
-                new KeyValuePair<int, int>(500, HasSourceCodeLink ? 1 : 0),
-                // - open for collab / has collaborators
-                new KeyValuePair<int, int>(500, OpenForCollab ? 1 : 0),
-            };
-
-            //TODO:
-            // - works on latest umbraco versions
-            // - download count in a recent timeframe - since old downloads should count for less
-
-            var pop = 0;
-            foreach (var val in ranking)
-            {
-                pop += val.Key * val.Value;
-            }
-            return pop;
-        }
-    }
-
-    /// <summary>
     /// Data service used for projects
     /// </summary>
     public class ProjectNodeIndexDataService : ISimpleDataService
     {
-        public SimpleDataSet MapProjectToSimpleDataIndexItem(IPublishedContent project, SimpleDataSet simpleDataSet, string indexType,
+        
+
+        public SimpleDataSet MapProjectToSimpleDataIndexItem(
+            IDictionary<int, MonthlyProjectDownloads> projectDownloadStats,
+            DateTime mostRecentUpdateDate,
+            IPublishedContent project, SimpleDataSet simpleDataSet, string indexType,
             int projectVotes, WikiFile[] files, int downloads, IEnumerable<string> compatVersions)
         {
             var isLive = project.GetPropertyValue<bool>("projectLive");
@@ -195,11 +84,19 @@ namespace OurUmbraco.Our.Examine
             
             var hasForum = project.Children.Any(x => x.IsVisible());
 
-            var points = new ProjectPopularityPoints(project.CreateDate, project.UpdateDate,
+            MonthlyProjectDownloads projStats = null;
+            projectDownloadStats.TryGetValue(project.Id, out projStats);
+
+            var points = new ProjectPopularityPoints(                
+                mostRecentUpdateDate,
+                projStats,
+                project.CreateDate, 
+                project.UpdateDate,
                 project.GetPropertyValue<bool>("worksOnUaaS"), hasForum,
                 project.GetPropertyValue<string>("sourceUrl").IsNullOrWhiteSpace() == false,
                 project.GetPropertyValue<bool>("openForCollab"),
-                downloads, projectVotes);
+                downloads, 
+                projectVotes);
             var pop = points.Calculate();
 
             simpleDataSet.RowData.Add("popularity", pop.ToString());
@@ -235,6 +132,8 @@ namespace OurUmbraco.Our.Examine
             var allProjectWikiFiles = WikiFile.CurrentFiles(allProjectIds);
             var allProjectDownloads = Utils.GetProjectTotalPackageDownload();
             var allCompatVersions = Utils.GetProjectCompatibleVersions();
+            var mostRecentDownloadDate = WikiFile.GetMostRecentDownloadDate();
+            var downloadStats = WikiFile.GetMonthlyDownloadStatsByProject(mostRecentDownloadDate.Subtract(TimeSpan.FromDays(365)));            
 
             foreach (var project in projects)
             {
@@ -247,7 +146,10 @@ namespace OurUmbraco.Our.Examine
                 var projectFiles = allProjectWikiFiles.ContainsKey(project.Id) ? allProjectWikiFiles[project.Id].ToArray() : new WikiFile[] { };
                 var projectVersions = allCompatVersions.ContainsKey(project.Id) ? allCompatVersions[project.Id] : Enumerable.Empty<string>();
 
-                yield return MapProjectToSimpleDataIndexItem(project, simpleDataSet, indexType, projectKarma, projectFiles, projectDownloads, projectVersions);
+                yield return MapProjectToSimpleDataIndexItem(
+                    downloadStats,
+                    mostRecentDownloadDate,                    
+                    project, simpleDataSet, indexType, projectKarma, projectFiles, projectDownloads, projectVersions);
             }
         }
 
@@ -383,5 +285,7 @@ namespace OurUmbraco.Our.Examine
             }
 
         }
+
+        
     }
 }

--- a/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
+++ b/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using OurUmbraco.Wiki.Models;
+
+namespace OurUmbraco.Our.Examine
+{
+    /// <summary>
+    /// Used to calculate popularity
+    /// </summary>
+    /// <remarks>
+    /// This is a struct because it's a tiny object that we don't want hanging around in memory and is created for every project.
+    /// </remarks>
+    public struct ProjectPopularityPoints
+    {
+        public ProjectPopularityPoints(
+            DateTime now,
+            MonthlyProjectDownloads projectDownloads, 
+            DateTime createDate, DateTime updateDate, bool worksOnCloud, bool hasForum, bool hasSourceCodeLink, bool openForCollab, int downloads, int votes)
+        {
+            _now = now;
+            _projectDownloads = projectDownloads;
+            _createDate = createDate;
+            _updateDate = updateDate;
+            _worksOnCloud = worksOnCloud;
+            _hasForum = hasForum;
+            _hasSourceCodeLink = hasSourceCodeLink;
+            _openForCollab = openForCollab;
+            _downloads = downloads;
+            _votes = votes;
+        }
+
+        private readonly DateTime _now;
+        private readonly MonthlyProjectDownloads _projectDownloads;
+        private readonly DateTime _createDate;
+        private readonly DateTime _updateDate;
+        private readonly bool _worksOnCloud;
+        private readonly bool _hasForum;
+        private readonly bool _hasSourceCodeLink;
+        private readonly bool _openForCollab;
+        private readonly int _downloads;
+        private readonly int _votes;
+
+        public DateTime CreateDate
+        {
+            get { return _createDate; }
+        }
+
+        public DateTime UpdateDate
+        {
+            get { return _updateDate; }
+        }
+
+        public bool WorksOnCloud
+        {
+            get { return _worksOnCloud; }
+        }
+
+        public bool HasForum
+        {
+            get { return _hasForum; }
+        }
+
+        public bool HasSourceCodeLink
+        {
+            get { return _hasSourceCodeLink; }
+        }
+
+        public bool OpenForCollab
+        {
+            get { return _openForCollab; }
+        }
+
+        public int Downloads
+        {
+            get { return _downloads; }
+        }
+
+        public int Votes
+        {
+            get { return _votes; }
+        }
+
+        private int GetDownloadScore()
+        {
+            if (_projectDownloads == null) return 0;
+
+            var score = 0;
+
+            var downloadsLast6Months = _projectDownloads.GetLatestDownloads(_now, 6);
+            score += downloadsLast6Months;
+
+            //get the previous 6 month downloads
+            var downloadsLast12Months = _projectDownloads.GetLatestDownloads(_now, 12) - downloadsLast6Months;
+            score += downloadsLast12Months;
+
+            return score;
+        }
+
+        private int GetUpdateDateScore()
+        {
+            //sort of an exponential calculation on recent update date
+            var days = (_now - UpdateDate).Days;
+
+            if (days <= 30) return 5;
+            if (days <= 60) return 4;
+            if (days <= 100) return 3;
+            if (days <= 200) return 2;
+            if (days <= 355) return 1;
+            return 0;
+        }
+
+        public int Calculate()
+        {
+            var downloadScore = GetDownloadScore();
+            var updateScore = GetUpdateDateScore();
+
+            //Each factor is rated (on various scales), then we can boost each factor accordingly
+            //the boost factor is the first value
+            var ranking = new List<KeyValuePair<int, int>>
+            {
+                // - download count in a recent timeframe - since old downloads should count for less
+                new KeyValuePair<int, int>(1, downloadScore),
+                // - votes
+                new KeyValuePair<int, int>(20, Votes),
+                // - recently updated            
+                new KeyValuePair<int, int>(100, updateScore),
+                // - works on Cloud
+                new KeyValuePair<int, int>(250, WorksOnCloud ? 1 : 0),
+                // - has a forum
+                new KeyValuePair<int, int>(100, HasForum ? 1 : 0),
+                // - has source code link
+                new KeyValuePair<int, int>(500, HasSourceCodeLink ? 1 : 0),
+                // - open for collab / has collaborators
+                new KeyValuePair<int, int>(250, OpenForCollab ? 1 : 0),
+            };
+
+            //TODO:
+            // - works on latest umbraco versions            
+
+            var pop = 0;
+            foreach (var val in ranking)
+            {
+                pop += val.Key * val.Value;
+            }
+            return pop;
+        }
+    }
+}

--- a/OurUmbraco/Our/Utils.cs
+++ b/OurUmbraco/Our/Utils.cs
@@ -334,6 +334,7 @@ namespace OurUmbraco.Our
                 ? string.Format("<img src=\"{0}?width={1}&height={1}&mode=crop\" srcset=\"{0}?width={2}&height={2}&mode=crop 2x, {0}?width={3}&height={3}&mode=crop 3x\" alt=\"{4}\" />", imgPath.Replace(" ", "%20"), minSize, (minSize * 2), (minSize * 3), memberName)
                 : url;
         }
+        
     }
 
     public struct ReplacePoint

--- a/OurUmbraco/Our/Utils.cs
+++ b/OurUmbraco/Our/Utils.cs
@@ -145,6 +145,17 @@ namespace OurUmbraco.Our
         }
 
         /// <summary>
+        /// Returns a dictionary of project id => total downloads but only for package files
+        /// </summary>
+        /// <returns></returns>
+        public static Dictionary<int, int> GetProjectTotalPackageDownload()
+        {
+            return Umbraco.Core.ApplicationContext.Current.DatabaseContext.Database.Fetch<dynamic>(
+                "select nodeId as projectId, SUM(downloads) as total from wikiFiles WHERE [type] = 'package' GROUP BY nodeId")
+                .ToDictionary(x => (int)x.projectId, x => (int)x.total);
+        }
+
+        /// <summary>
         /// Returns a dictionary of project id => any version that has been flagged as being compatible
         /// </summary>
         /// <returns></returns>

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -546,6 +546,8 @@
     <Compile Include="Our\Controllers\AvatarController.cs" />
     <Compile Include="Our\Controllers\BreadcrumbController.cs" />
     <Compile Include="Our\Controllers\OurUmbracoController.cs" />
+    <Compile Include="Our\Examine\DateRangeSearchFilter.cs" />
+    <Compile Include="Our\Examine\ProjectPopularityPoints.cs" />
     <Compile Include="Our\Models\EditScreenshotModel.cs" />
     <Compile Include="Our\Models\EditFileModel.cs" />
     <Compile Include="Our\Models\EditProjectModel.cs" />
@@ -813,6 +815,7 @@
     <Compile Include="Wiki\iNotFoundHandler.cs" />
     <Compile Include="Wiki\Library\Utils.cs" />
     <Compile Include="Wiki\Library\xslt.cs" />
+    <Compile Include="Wiki\Models\MonthlyProjectDownloads.cs" />
     <Compile Include="Wiki\usercontrols\FileUpload.ascx.cs">
       <DependentUpon>FileUpload.ascx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/OurUmbraco/Project/ProjectExtensions.cs
+++ b/OurUmbraco/Project/ProjectExtensions.cs
@@ -107,21 +107,7 @@ namespace OurUmbraco.Project
             return str;
 
         }
-
-        public static string BuildExamineString(this string term, int boost, string field, bool andSearch)
-        {
-            term = Lucene.Net.QueryParsers.QueryParser.Escape(term);
-            var terms = term.Trim().Split(' ');
-            var qs = field + ":";
-            qs += "\"" + term + "\"^" + (boost + 30000).ToString() + " ";
-            qs += field + ":(+" + term.Replace(" ", " +") + ")^" + (boost + 5).ToString() + " ";
-            if (!andSearch)
-            {
-                qs += field + ":(" + term + ")^" + boost.ToString() + " ";
-            }
-            return qs;
-        }
-
+        
         public static string CleanHtmlAttributes(this string description)
         {
             var doc = new HtmlDocument();

--- a/OurUmbraco/Repository/Services/PackageRepositoryService.cs
+++ b/OurUmbraco/Repository/Services/PackageRepositoryService.cs
@@ -111,17 +111,6 @@ namespace OurUmbraco.Repository.Services
                 }
             }
 
-            //if (order == PackageSortOrder.Popular)
-            //{
-            //    //boost on more recently modified projects
-            //    searchFilters.Filters.Add(new DateRangeSearchFilter(
-            //        "updateDate",
-            //        //from one year ago to now
-            //        DateTime.Now - TimeSpan.FromDays(365),
-            //        DateTime.Now,
-            //        boost: 1000));
-            //}
-
             query = string.IsNullOrWhiteSpace(query) ? string.Empty : query;
 
             var orderBy = string.Empty;

--- a/OurUmbraco/Repository/Services/PackageRepositoryService.cs
+++ b/OurUmbraco/Repository/Services/PackageRepositoryService.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using Examine;
 using Examine.LuceneEngine;
 using Examine.SearchCriteria;
+using Lucene.Net.Documents;
 using OurUmbraco.Forum.Extensions;
 using OurUmbraco.MarketPlace.Providers;
 using OurUmbraco.Our;
@@ -109,6 +110,17 @@ namespace OurUmbraco.Repository.Services
                     filters.Add(versionFilters);
                 }
             }
+
+            //if (order == PackageSortOrder.Popular)
+            //{
+            //    //boost on more recently modified projects
+            //    searchFilters.Filters.Add(new DateRangeSearchFilter(
+            //        "updateDate",
+            //        //from one year ago to now
+            //        DateTime.Now - TimeSpan.FromDays(365),
+            //        DateTime.Now,
+            //        boost: 1000));
+            //}
 
             query = string.IsNullOrWhiteSpace(query) ? string.Empty : query;
 

--- a/OurUmbraco/Wiki/Models/MonthlyProjectDownloads.cs
+++ b/OurUmbraco/Wiki/Models/MonthlyProjectDownloads.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OurUmbraco.Wiki.Models
+{
+    public class MonthlyProjectDownloads
+    {
+        private readonly Dictionary<int, Dictionary<int, int>> _stats = new Dictionary<int, Dictionary<int, int>>();
+
+        public void AddMonthlyStats(int year, int quarter, int downloads)
+        {
+            Dictionary<int, int> monthly;
+            if (_stats.TryGetValue(year, out monthly) == false)
+            {
+                monthly = new Dictionary<int, int>();
+                _stats[year] = monthly;
+            }
+            monthly[quarter] = downloads;
+        }
+
+        public int GetYearlyDownloads(int year)
+        {
+            Dictionary<int, int> monthly;
+            if (_stats.TryGetValue(year, out monthly) == false)
+                return 0;
+            return monthly.Sum(x => x.Value);
+        }
+
+        public int GetMonthlyDownloads(int year, int month)
+        {
+            Dictionary<int, int> monthly;
+            if (_stats.TryGetValue(year, out monthly) == false)
+                return 0;
+            int downloads;
+            if (monthly.TryGetValue(month, out downloads) == false)
+                return 0;
+            return downloads;
+        }
+
+        public int GetLatestDownloads(DateTime now, int months)
+        {
+            var year = now.Year;
+            var month = now.Month;
+
+            //32 is more days than any month so we are being safe here
+            var minYear = now.Subtract(TimeSpan.FromDays(months * 32)).Year - 1;
+
+            var iterations = 0;
+            var sum = 0;
+
+            while (year > minYear)
+            {  
+                while (month > 0)
+                {
+                    //see if the current year is logged for this project
+                    Dictionary<int, int> monthly;
+                    if (_stats.TryGetValue(year, out monthly))
+                    {
+                        //then check if the current month is logged for this project
+                        int downloads;
+                        if (monthly.TryGetValue(month, out downloads))
+                        {
+                            sum += downloads;
+                        }                        
+                    }
+                    month--;
+                    iterations++;
+                    //exit early once iterations match number of months
+                    if (iterations >= months)
+                        return sum;
+                }
+
+                year--;
+                //reset
+                month = 12;
+            }
+            
+            return sum;
+        }
+    }
+}


### PR DESCRIPTION
popularity takes into account

// - download count in a recent timeframe - since old downloads should count for less
// - votes
// - recently updated            
// - works on Cloud
// - has a forum
// - has source code link
// - open for collab / has collaborators

TODO: 
// - works on latest umbraco versions            

Each of those items then has a weighting which can be adjusted. The download counts and recently updated also have their own aglorithms for creating a numerical value to score against.

This yields much better results for popularity