### PR TITLE
Form method changed to pass form values as querystring params

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Releases/ReleasesDropdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Releases/ReleasesDropdown.cshtml
@@ -60,7 +60,7 @@
         fromVersion = sortedVersions.Skip(sortedVersions.Count - 2).First().Key;
     }
 
-    <form name="compare" method="post">
+    <form name="compare" method="get">
         <div class="row">
             <div class="col-xs-6 col-sm-4">
                 <div class="row">


### PR DESCRIPTION
I noticed that versions during comparison on https://our.umbraco.org/contribute/releases/compare page are not passed as a query string parameters and the result cannot be easily shared between people. 

I thought the whole feature is missing, but I noticed everything is there, but the wrong form method was causing those params to dissapear. 

Changing it from POST to GET fixed the problem. Hope it will help others too :)