### PR TITLE
Fix typos in account approval notification email

### DIFF
--- a/OurUmbraco.Site/config/Notification.config
+++ b/OurUmbraco.Site/config/Notification.config
@@ -67,10 +67,10 @@ You can unsubscribe from your profile on our.umbraco.org
       <subject>Umbraco community: Account approved</subject>
       <body>Hi there! 
       
-You recently posted on the our.umbraco.org forum for one of your first times. 
+You recently posted on the our.umbraco.org forum for the first time. 
 This triggered a manual check to make sure you weren't posting any spam.
 
-Good news: one of our moderators has just approved your accounta and your future posts will no longer be marked for manual approval.
+Good news: one of our moderators has just approved your account and your future posts will no longer be marked for manual approval.
 
 We're sorry for the inconvenience; We're dealing with a spam problem that cannot be fought with automated systems. Therefore, we approve each account that has a low number of posts manually.
 


### PR DESCRIPTION
Noticed some small typos when I received the account approval email.