### PR TITLE
Videos: Added "All videos" menu item

### DIFF
--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -4362,7 +4362,6 @@
     <Content Include="Views\CommunityMvps.cshtml" />
     <Content Include="Views\Partials\Community\MVPs.cshtml" />
     <Content Include="Views\Videos.cshtml" />
-    <Content Include="Views\Partials\Videos\Home.cshtml" />
 	<None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/OurUmbraco.Site/Views/Partials/Videos/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Videos/Home.cshtml
@@ -74,7 +74,9 @@
                 <div class="content-wrapper">
                     <nav>
                         <ul class="level-1">
-                                
+                            <li class="@(selectedCategory == null ? "active" : null)">
+                                <a href="@Model.Url"><h3>All videos</h3></a>
+                            </li>
                             @foreach (var category in categories)
                             {
                                 string name = category.Name.ToKebabCase();


### PR DESCRIPTION
I think this makes sense. Eg. to have a menu item that is selected by default.

The menu item doesn't listed the individual years as the logic currently doesn't support browsing those without a category - but should this be supported as well?

![image](https://user-images.githubusercontent.com/3634580/36394702-bde6a89e-15b5-11e8-8683-4d020f261e45.png)
