### PR TITLE
MVPs: Trim leading @ from social usernames

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Community/MVPs.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/MVPs.cshtml
@@ -89,8 +89,8 @@
                             {
 
                                 var company = member.GetValue<string>("company");
-                                var twitter = member.GetValue<string>("twitter");
-                                var github = member.GetValue<string>("github");
+                                var twitter = (member.GetValue<string>("twitter") ?? "").Trim().TrimStart('@');
+                                var github = (member.GetValue<string>("github") ?? "").Trim().TrimStart('@');
 
                                 // Hacky as we need IPublishedContent to render the avatar
                                 var m = membershipHelper.GetById(member.Id);


### PR DESCRIPTION
Some users have kept the @ in front of the username, so there are actually two @@ in front of their username. This commit will trim the username to make sure there is only a single @.

This appears to be isolated to the MVPs list as the profile page doesn't suffer from it.