### PR TITLE
Switch documentation Markdown conversion to use Markdig 

### DIFF
--- a/OurUmbraco.Client/src/scss/pages/_documentation.scss
+++ b/OurUmbraco.Client/src/scss/pages/_documentation.scss
@@ -362,7 +362,7 @@ $color-overview: lighten($color-our, 20%);
 
 
 
-    .col-xs-6 {
+    .col-xs-6, .col-sm-6 {
         min-height: 133px;
 
 

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -126,6 +126,9 @@
       <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Markdig, Version=0.14.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.0.14.9\lib\net40\Markdig.dll</HintPath>
+    </Reference>
     <Reference Include="MarkdownSharp, Version=1.14.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdown.1.14.7\lib\net45\MarkdownSharp.dll</HintPath>
       <Private>True</Private>
@@ -4362,7 +4365,7 @@
     <Content Include="Views\Partials\Grid\Bootstrap2.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap2-Fluid.cshtml" />
     <Content Include="Views\Partials\Community\KarmaStatistics.cshtml" />
-    <Content Include="Views\Partials\Videos\Home.cshtml" />    
+    <Content Include="Views\Partials\Videos\Home.cshtml" />
     <Content Include="Views\CommunityBlogs.cshtml" />
     <Content Include="Views\Partials\Community\Blogs.cshtml" />
     <Content Include="Views\Partials\Community\Statistics.cshtml" />
@@ -4380,13 +4383,13 @@
     <Content Include="Views\ProjectGroup.cshtml" />
     <Content Include="Views\ProjectsTags.cshtml" />
     <Content Include="Views\CommunityVideos.cshtml" />
-    <Content Include="Views\Partials\Community\Gitter.cshtml" />    
+    <Content Include="Views\Partials\Community\Gitter.cshtml" />
     <Content Include="Views\Partials\Grid\Editors\Textstring.cshtml" />
     <Content Include="Views\Partials\Grid\Editors\Rte.cshtml" />
     <Content Include="Views\Partials\Grid\Editors\Media.cshtml" />
     <Content Include="Views\Partials\Grid\Editors\Macro.cshtml" />
     <Content Include="Views\Partials\Videos\Home.cshtml" />
-    <Content Include="Views\Partials\Community\Videos.cshtml" />    
+    <Content Include="Views\Partials\Community\Videos.cshtml" />
     <Content Include="Views\Partials\Grid\Editors\Base.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap3.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap3-Fluid.cshtml" />

--- a/OurUmbraco.Site/packages.config
+++ b/OurUmbraco.Site/packages.config
@@ -21,6 +21,7 @@
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Log4Net.Async" version="2.0.4" targetFramework="net452" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net452" />
+  <package id="Markdig" version="0.14.9" targetFramework="net452" />
   <package id="Markdown" version="1.14.7" targetFramework="net452" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net4" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net451" />

--- a/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
+++ b/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text.RegularExpressions;
-using MarkdownDeep;
+using Markdig;
+
 
 namespace OurUmbraco.Documentation.Busineslogic
 {
@@ -41,8 +41,9 @@ namespace OurUmbraco.Documentation.Busineslogic
                 var clean = Regex.Replace(text, MarkdownLogic.RegEx, new MatchEvaluator(match => LinkEvaluator(match, PrefixLinks)),
                     RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace);
 
-                Markdown md = new Markdown();
-                string transform = md.Transform(clean);
+                var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+                var transform = Markdown.ToHtml(clean, pipeline);
+
                 return transform;
             }
 

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -120,6 +120,9 @@
       <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Markdig, Version=0.14.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.0.14.9\lib\net40\Markdig.dll</HintPath>
+    </Reference>
     <Reference Include="MarkdownDeep, Version=1.5.4615.26275, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
       <Private>True</Private>

--- a/OurUmbraco/packages.config
+++ b/OurUmbraco/packages.config
@@ -21,6 +21,7 @@
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Log4Net.Async" version="2.0.4" targetFramework="net452" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net452" />
+  <package id="Markdig" version="0.14.9" targetFramework="net452" />
   <package id="Markdown" version="1.14.7" targetFramework="net452" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net451" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net451" />


### PR DESCRIPTION
Switch documentation Markdown conversion to use Markdig so that it supports all things GitHub such as tables and GFM code blocks