### PR TITLE
Google Map - Display members around the world

### DIFF
--- a/OurUmbraco.Site/Assets/js/lib/markerclusterer.js
+++ b/OurUmbraco.Site/Assets/js/lib/markerclusterer.js
@@ -1,0 +1,1288 @@
+// ==ClosureCompiler==
+// @compilation_level ADVANCED_OPTIMIZATIONS
+// @externs_url http://closure-compiler.googlecode.com/svn/trunk/contrib/externs/maps/google_maps_api_v3_3.js
+// ==/ClosureCompiler==
+
+/**
+ * @name MarkerClusterer for Google Maps v3
+ * @version version 1.0.1
+ * @author Luke Mahe
+ * @fileoverview
+ * The library creates and manages per-zoom-level clusters for large amounts of
+ * markers.
+ */
+
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * A Marker Clusterer that clusters markers.
+ *
+ * @param {google.maps.Map} map The Google map to attach to.
+ * @param {Array.<google.maps.Marker>=} opt_markers Optional markers to add to
+ *   the cluster.
+ * @param {Object=} opt_options support the following options:
+ *     'gridSize': (number) The grid size of a cluster in pixels.
+ *     'maxZoom': (number) The maximum zoom level that a marker can be part of a
+ *                cluster.
+ *     'zoomOnClick': (boolean) Whether the default behaviour of clicking on a
+ *                    cluster is to zoom into it.
+ *     'imagePath': (string) The base URL where the images representing
+ *                  clusters will be found. The full URL will be:
+ *                  {imagePath}[1-5].{imageExtension}
+ *                  Default: '../images/m'.
+ *     'imageExtension': (string) The suffix for images URL representing
+ *                       clusters will be found. See _imagePath_ for details.
+ *                       Default: 'png'.
+ *     'averageCenter': (boolean) Whether the center of each cluster should be
+ *                      the average of all markers in the cluster.
+ *     'minimumClusterSize': (number) The minimum number of markers to be in a
+ *                           cluster before the markers are hidden and a count
+ *                           is shown.
+ *     'styles': (object) An object that has style properties:
+ *       'url': (string) The image url.
+ *       'height': (number) The image height.
+ *       'width': (number) The image width.
+ *       'anchor': (Array) The anchor position of the label text.
+ *       'textColor': (string) The text color.
+ *       'textSize': (number) The text size.
+ *       'backgroundPosition': (string) The position of the backgound x, y.
+ * @constructor
+ * @extends google.maps.OverlayView
+ */
+function MarkerClusterer(map, opt_markers, opt_options) {
+    // MarkerClusterer implements google.maps.OverlayView interface. We use the
+    // extend function to extend MarkerClusterer with google.maps.OverlayView
+    // because it might not always be available when the code is defined so we
+    // look for it at the last possible moment. If it doesn't exist now then
+    // there is no point going ahead :)
+    this.extend(MarkerClusterer, google.maps.OverlayView);
+    this.map_ = map;
+
+    /**
+     * @type {Array.<google.maps.Marker>}
+     * @private
+     */
+    this.markers_ = [];
+
+    /**
+     *  @type {Array.<Cluster>}
+     */
+    this.clusters_ = [];
+
+    this.sizes = [53, 56, 66, 78, 90];
+
+    /**
+     * @private
+     */
+    this.styles_ = [];
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.ready_ = false;
+
+    var options = opt_options || {};
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.gridSize_ = options['gridSize'] || 60;
+
+    /**
+     * @private
+     */
+    this.minClusterSize_ = options['minimumClusterSize'] || 2;
+
+
+    /**
+     * @type {?number}
+     * @private
+     */
+    this.maxZoom_ = options['maxZoom'] || null;
+
+    this.styles_ = options['styles'] || [];
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.imagePath_ = options['imagePath'] || this.MARKER_CLUSTER_IMAGE_PATH_;
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.imageExtension_ = options['imageExtension'] || this.MARKER_CLUSTER_IMAGE_EXTENSION_;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.zoomOnClick_ = true;
+
+    if (options['zoomOnClick'] != undefined) {
+        this.zoomOnClick_ = options['zoomOnClick'];
+    }
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.averageCenter_ = false;
+
+    if (options['averageCenter'] != undefined) {
+        this.averageCenter_ = options['averageCenter'];
+    }
+
+    this.setupStyles_();
+
+    this.setMap(map);
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.prevZoom_ = this.map_.getZoom();
+
+    // Add the map event listeners
+    var that = this;
+    google.maps.event.addListener(this.map_, 'zoom_changed', function() {
+        // Determines map type and prevent illegal zoom levels
+        var zoom = that.map_.getZoom();
+        var minZoom = that.map_.minZoom || 0;
+        var maxZoom = Math.min(that.map_.maxZoom || 100,
+        that.map_.mapTypes[that.map_.getMapTypeId()].maxZoom);
+        zoom = Math.min(Math.max(zoom, minZoom), maxZoom);
+
+        if (that.prevZoom_ != zoom) {
+            that.prevZoom_ = zoom;
+            that.resetViewport();
+        }
+    });
+
+    google.maps.event.addListener(this.map_, 'idle', function() {
+        that.redraw();
+    });
+
+    // Finally, add the markers
+    if (opt_markers && (opt_markers.length || Object.keys(opt_markers).length)) {
+        this.addMarkers(opt_markers, false);
+    }
+}
+
+
+/**
+ * The marker cluster image path.
+ *
+ * @type {string}
+ * @private
+ */
+MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ = '../images/m';
+
+
+/**
+ * The marker cluster image path.
+ *
+ * @type {string}
+ * @private
+ */
+MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_EXTENSION_ = 'png';
+
+
+/**
+ * Extends a objects prototype by anothers.
+ *
+ * @param {Object} obj1 The object to be extended.
+ * @param {Object} obj2 The object to extend with.
+ * @return {Object} The new extended object.
+ * @ignore
+ */
+MarkerClusterer.prototype.extend = function(obj1, obj2) {
+    return (function(object) {
+        for (var property in object.prototype) {
+            this.prototype[property] = object.prototype[property];
+        }
+        return this;
+    }).apply(obj1, [obj2]);
+};
+
+
+/**
+ * Implementaion of the interface method.
+ * @ignore
+ */
+MarkerClusterer.prototype.onAdd = function() {
+    this.setReady_(true);
+};
+
+/**
+ * Implementaion of the interface method.
+ * @ignore
+ */
+MarkerClusterer.prototype.draw = function() {};
+
+/**
+ * Sets up the styles object.
+ *
+ * @private
+ */
+MarkerClusterer.prototype.setupStyles_ = function() {
+    if (this.styles_.length) {
+        return;
+    }
+
+    for (var i = 0, size; size = this.sizes[i]; i++) {
+        this.styles_.push({
+            url: this.imagePath_ + (i + 1) + '.' + this.imageExtension_,
+            height: size,
+            width: size
+        });
+    }
+};
+
+/**
+ *  Fit the map to the bounds of the markers in the clusterer.
+ */
+MarkerClusterer.prototype.fitMapToMarkers = function() {
+    var markers = this.getMarkers();
+    var bounds = new google.maps.LatLngBounds();
+    for (var i = 0, marker; marker = markers[i]; i++) {
+        bounds.extend(marker.getPosition());
+    }
+
+    this.map_.fitBounds(bounds);
+};
+
+
+/**
+ *  Sets the styles.
+ *
+ *  @param {Object} styles The style to set.
+ */
+MarkerClusterer.prototype.setStyles = function(styles) {
+    this.styles_ = styles;
+};
+
+
+/**
+ *  Gets the styles.
+ *
+ *  @return {Object} The styles object.
+ */
+MarkerClusterer.prototype.getStyles = function() {
+    return this.styles_;
+};
+
+
+/**
+ * Whether zoom on click is set.
+ *
+ * @return {boolean} True if zoomOnClick_ is set.
+ */
+MarkerClusterer.prototype.isZoomOnClick = function() {
+    return this.zoomOnClick_;
+};
+
+/**
+ * Whether average center is set.
+ *
+ * @return {boolean} True if averageCenter_ is set.
+ */
+MarkerClusterer.prototype.isAverageCenter = function() {
+    return this.averageCenter_;
+};
+
+
+/**
+ *  Returns the array of markers in the clusterer.
+ *
+ *  @return {Array.<google.maps.Marker>} The markers.
+ */
+MarkerClusterer.prototype.getMarkers = function() {
+    return this.markers_;
+};
+
+
+/**
+ *  Returns the number of markers in the clusterer
+ *
+ *  @return {Number} The number of markers.
+ */
+MarkerClusterer.prototype.getTotalMarkers = function() {
+    return this.markers_.length;
+};
+
+
+/**
+ *  Sets the max zoom for the clusterer.
+ *
+ *  @param {number} maxZoom The max zoom level.
+ */
+MarkerClusterer.prototype.setMaxZoom = function(maxZoom) {
+    this.maxZoom_ = maxZoom;
+};
+
+
+/**
+ *  Gets the max zoom for the clusterer.
+ *
+ *  @return {number} The max zoom level.
+ */
+MarkerClusterer.prototype.getMaxZoom = function() {
+    return this.maxZoom_;
+};
+
+
+/**
+ *  The function for calculating the cluster icon image.
+ *
+ *  @param {Array.<google.maps.Marker>} markers The markers in the clusterer.
+ *  @param {number} numStyles The number of styles available.
+ *  @return {Object} A object properties: 'text' (string) and 'index' (number).
+ *  @private
+ */
+MarkerClusterer.prototype.calculator_ = function(markers, numStyles) {
+    var index = 0;
+    var count = markers.length;
+    var dv = count;
+    while (dv !== 0) {
+        dv = parseInt(dv / 10, 10);
+        index++;
+    }
+
+    index = Math.min(index, numStyles);
+    return {
+        text: count,
+        index: index
+    };
+};
+
+
+/**
+ * Set the calculator function.
+ *
+ * @param {function(Array, number)} calculator The function to set as the
+ *     calculator. The function should return a object properties:
+ *     'text' (string) and 'index' (number).
+ *
+ */
+MarkerClusterer.prototype.setCalculator = function(calculator) {
+    this.calculator_ = calculator;
+};
+
+
+/**
+ * Get the calculator function.
+ *
+ * @return {function(Array, number)} the calculator function.
+ */
+MarkerClusterer.prototype.getCalculator = function() {
+    return this.calculator_;
+};
+
+
+/**
+ * Add an array of markers to the clusterer.
+ *
+ * @param {Array.<google.maps.Marker>} markers The markers to add.
+ * @param {boolean=} opt_nodraw Whether to redraw the clusters.
+ */
+MarkerClusterer.prototype.addMarkers = function(markers, opt_nodraw) {
+    if (markers.length) {
+        for (var i = 0, marker; marker = markers[i]; i++) {
+            this.pushMarkerTo_(marker);
+        }
+    } else if (Object.keys(markers).length) {
+        for (var marker in markers) {
+            this.pushMarkerTo_(markers[marker]);
+        }
+    }
+    if (!opt_nodraw) {
+        this.redraw();
+    }
+};
+
+
+/**
+ * Pushes a marker to the clusterer.
+ *
+ * @param {google.maps.Marker} marker The marker to add.
+ * @private
+ */
+MarkerClusterer.prototype.pushMarkerTo_ = function(marker) {
+    marker.isAdded = false;
+    if (marker['draggable']) {
+        // If the marker is draggable add a listener so we update the clusters on
+        // the drag end.
+        var that = this;
+        google.maps.event.addListener(marker, 'dragend', function() {
+            marker.isAdded = false;
+            that.repaint();
+        });
+    }
+    this.markers_.push(marker);
+};
+
+
+/**
+ * Adds a marker to the clusterer and redraws if needed.
+ *
+ * @param {google.maps.Marker} marker The marker to add.
+ * @param {boolean=} opt_nodraw Whether to redraw the clusters.
+ */
+MarkerClusterer.prototype.addMarker = function(marker, opt_nodraw) {
+    this.pushMarkerTo_(marker);
+    if (!opt_nodraw) {
+        this.redraw();
+    }
+};
+
+
+/**
+ * Removes a marker and returns true if removed, false if not
+ *
+ * @param {google.maps.Marker} marker The marker to remove
+ * @return {boolean} Whether the marker was removed or not
+ * @private
+ */
+MarkerClusterer.prototype.removeMarker_ = function(marker) {
+    var index = -1;
+    if (this.markers_.indexOf) {
+        index = this.markers_.indexOf(marker);
+    } else {
+        for (var i = 0, m; m = this.markers_[i]; i++) {
+            if (m == marker) {
+                index = i;
+                break;
+            }
+        }
+    }
+
+    if (index == -1) {
+        // Marker is not in our list of markers.
+        return false;
+    }
+
+    marker.setMap(null);
+
+    this.markers_.splice(index, 1);
+
+    return true;
+};
+
+
+/**
+ * Remove a marker from the cluster.
+ *
+ * @param {google.maps.Marker} marker The marker to remove.
+ * @param {boolean=} opt_nodraw Optional boolean to force no redraw.
+ * @return {boolean} True if the marker was removed.
+ */
+MarkerClusterer.prototype.removeMarker = function(marker, opt_nodraw) {
+    var removed = this.removeMarker_(marker);
+
+    if (!opt_nodraw && removed) {
+        this.resetViewport();
+        this.redraw();
+        return true;
+    } else {
+        return false;
+    }
+};
+
+
+/**
+ * Removes an array of markers from the cluster.
+ *
+ * @param {Array.<google.maps.Marker>} markers The markers to remove.
+ * @param {boolean=} opt_nodraw Optional boolean to force no redraw.
+ */
+MarkerClusterer.prototype.removeMarkers = function(markers, opt_nodraw) {
+    // create a local copy of markers if required
+    // (removeMarker_ modifies the getMarkers() array in place)
+    var markersCopy = markers === this.getMarkers() ? markers.slice() : markers;
+    var removed = false;
+
+    for (var i = 0, marker; marker = markersCopy[i]; i++) {
+        var r = this.removeMarker_(marker);
+        removed = removed || r;
+    }
+
+    if (!opt_nodraw && removed) {
+        this.resetViewport();
+        this.redraw();
+        return true;
+    }
+};
+
+
+/**
+ * Sets the clusterer's ready state.
+ *
+ * @param {boolean} ready The state.
+ * @private
+ */
+MarkerClusterer.prototype.setReady_ = function(ready) {
+    if (!this.ready_) {
+        this.ready_ = ready;
+        this.createClusters_();
+    }
+};
+
+
+/**
+ * Returns the number of clusters in the clusterer.
+ *
+ * @return {number} The number of clusters.
+ */
+MarkerClusterer.prototype.getTotalClusters = function() {
+    return this.clusters_.length;
+};
+
+
+/**
+ * Returns the google map that the clusterer is associated with.
+ *
+ * @return {google.maps.Map} The map.
+ */
+MarkerClusterer.prototype.getMap = function() {
+    return this.map_;
+};
+
+
+/**
+ * Sets the google map that the clusterer is associated with.
+ *
+ * @param {google.maps.Map} map The map.
+ */
+MarkerClusterer.prototype.setMap = function(map) {
+    this.map_ = map;
+};
+
+
+/**
+ * Returns the size of the grid.
+ *
+ * @return {number} The grid size.
+ */
+MarkerClusterer.prototype.getGridSize = function() {
+    return this.gridSize_;
+};
+
+
+/**
+ * Sets the size of the grid.
+ *
+ * @param {number} size The grid size.
+ */
+MarkerClusterer.prototype.setGridSize = function(size) {
+    this.gridSize_ = size;
+};
+
+
+/**
+ * Returns the min cluster size.
+ *
+ * @return {number} The grid size.
+ */
+MarkerClusterer.prototype.getMinClusterSize = function() {
+    return this.minClusterSize_;
+};
+
+/**
+ * Sets the min cluster size.
+ *
+ * @param {number} size The grid size.
+ */
+MarkerClusterer.prototype.setMinClusterSize = function(size) {
+    this.minClusterSize_ = size;
+};
+
+
+/**
+ * Extends a bounds object by the grid size.
+ *
+ * @param {google.maps.LatLngBounds} bounds The bounds to extend.
+ * @return {google.maps.LatLngBounds} The extended bounds.
+ */
+MarkerClusterer.prototype.getExtendedBounds = function(bounds) {
+    var projection = this.getProjection();
+
+    // Turn the bounds into latlng.
+    var tr = new google.maps.LatLng(bounds.getNorthEast().lat(),
+    bounds.getNorthEast().lng());
+    var bl = new google.maps.LatLng(bounds.getSouthWest().lat(),
+    bounds.getSouthWest().lng());
+
+    // Convert the points to pixels and the extend out by the grid size.
+    var trPix = projection.fromLatLngToDivPixel(tr);
+    trPix.x += this.gridSize_;
+    trPix.y -= this.gridSize_;
+
+    var blPix = projection.fromLatLngToDivPixel(bl);
+    blPix.x -= this.gridSize_;
+    blPix.y += this.gridSize_;
+
+    // Convert the pixel points back to LatLng
+    var ne = projection.fromDivPixelToLatLng(trPix);
+    var sw = projection.fromDivPixelToLatLng(blPix);
+
+    // Extend the bounds to contain the new bounds.
+    bounds.extend(ne);
+    bounds.extend(sw);
+
+    return bounds;
+};
+
+
+/**
+ * Determins if a marker is contained in a bounds.
+ *
+ * @param {google.maps.Marker} marker The marker to check.
+ * @param {google.maps.LatLngBounds} bounds The bounds to check against.
+ * @return {boolean} True if the marker is in the bounds.
+ * @private
+ */
+MarkerClusterer.prototype.isMarkerInBounds_ = function(marker, bounds) {
+    return bounds.contains(marker.getPosition());
+};
+
+
+/**
+ * Clears all clusters and markers from the clusterer.
+ */
+MarkerClusterer.prototype.clearMarkers = function() {
+    this.resetViewport(true);
+
+    // Set the markers a empty array.
+    this.markers_ = [];
+};
+
+
+/**
+ * Clears all existing clusters and recreates them.
+ * @param {boolean} opt_hide To also hide the marker.
+ */
+MarkerClusterer.prototype.resetViewport = function(opt_hide) {
+    // Remove all the clusters
+    for (var i = 0, cluster; cluster = this.clusters_[i]; i++) {
+        cluster.remove();
+    }
+
+    // Reset the markers to not be added and to be invisible.
+    for (var i = 0, marker; marker = this.markers_[i]; i++) {
+        marker.isAdded = false;
+        if (opt_hide) {
+            marker.setMap(null);
+        }
+    }
+
+    this.clusters_ = [];
+};
+
+/**
+ *
+ */
+MarkerClusterer.prototype.repaint = function() {
+    var oldClusters = this.clusters_.slice();
+    this.clusters_.length = 0;
+    this.resetViewport();
+    this.redraw();
+
+    // Remove the old clusters.
+    // Do it in a timeout so the other clusters have been drawn first.
+    window.setTimeout(function() {
+        for (var i = 0, cluster; cluster = oldClusters[i]; i++) {
+            cluster.remove();
+        }
+    }, 0);
+};
+
+
+/**
+ * Redraws the clusters.
+ */
+MarkerClusterer.prototype.redraw = function() {
+    this.createClusters_();
+};
+
+
+/**
+ * Calculates the distance between two latlng locations in km.
+ * @see http://www.movable-type.co.uk/scripts/latlong.html
+ *
+ * @param {google.maps.LatLng} p1 The first lat lng point.
+ * @param {google.maps.LatLng} p2 The second lat lng point.
+ * @return {number} The distance between the two points in km.
+ * @private
+ */
+MarkerClusterer.prototype.distanceBetweenPoints_ = function(p1, p2) {
+    if (!p1 || !p2) {
+        return 0;
+    }
+
+    var R = 6371; // Radius of the Earth in km
+    var dLat = (p2.lat() - p1.lat()) * Math.PI / 180;
+    var dLon = (p2.lng() - p1.lng()) * Math.PI / 180;
+    var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) + Math.cos(p1.lat() * Math.PI / 180) * Math.cos(p2.lat() * Math.PI / 180) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    var d = R * c;
+    return d;
+};
+
+
+/**
+ * Add a marker to a cluster, or creates a new cluster.
+ *
+ * @param {google.maps.Marker} marker The marker to add.
+ * @private
+ */
+MarkerClusterer.prototype.addToClosestCluster_ = function(marker) {
+    var distance = 40000; // Some large number
+    var clusterToAddTo = null;
+    var pos = marker.getPosition();
+    for (var i = 0, cluster; cluster = this.clusters_[i]; i++) {
+        var center = cluster.getCenter();
+        if (center) {
+            var d = this.distanceBetweenPoints_(center, marker.getPosition());
+            if (d < distance) {
+                distance = d;
+                clusterToAddTo = cluster;
+            }
+        }
+    }
+
+    if (clusterToAddTo && clusterToAddTo.isMarkerInClusterBounds(marker)) {
+        clusterToAddTo.addMarker(marker);
+    } else {
+        var cluster = new Cluster(this);
+        cluster.addMarker(marker);
+        this.clusters_.push(cluster);
+    }
+};
+
+
+/**
+ * Creates the clusters.
+ *
+ * @private
+ */
+MarkerClusterer.prototype.createClusters_ = function() {
+    if (!this.ready_) {
+        return;
+    }
+
+    // Get our current map view bounds.
+    // Create a new bounds object so we don't affect the map.
+    var mapBounds = new google.maps.LatLngBounds(this.map_.getBounds().getSouthWest(),
+    this.map_.getBounds().getNorthEast());
+    var bounds = this.getExtendedBounds(mapBounds);
+
+    for (var i = 0, marker; marker = this.markers_[i]; i++) {
+        if (!marker.isAdded && this.isMarkerInBounds_(marker, bounds)) {
+            this.addToClosestCluster_(marker);
+        }
+    }
+};
+
+
+/**
+ * A cluster that contains markers.
+ *
+ * @param {MarkerClusterer} markerClusterer The markerclusterer that this
+ *     cluster is associated with.
+ * @constructor
+ * @ignore
+ */
+function Cluster(markerClusterer) {
+    this.markerClusterer_ = markerClusterer;
+    this.map_ = markerClusterer.getMap();
+    this.gridSize_ = markerClusterer.getGridSize();
+    this.minClusterSize_ = markerClusterer.getMinClusterSize();
+    this.averageCenter_ = markerClusterer.isAverageCenter();
+    this.center_ = null;
+    this.markers_ = [];
+    this.bounds_ = null;
+    this.clusterIcon_ = new ClusterIcon(this, markerClusterer.getStyles(),
+    markerClusterer.getGridSize());
+}
+
+/**
+ * Determins if a marker is already added to the cluster.
+ *
+ * @param {google.maps.Marker} marker The marker to check.
+ * @return {boolean} True if the marker is already added.
+ */
+Cluster.prototype.isMarkerAlreadyAdded = function(marker) {
+    if (this.markers_.indexOf) {
+        return this.markers_.indexOf(marker) != -1;
+    } else {
+        for (var i = 0, m; m = this.markers_[i]; i++) {
+            if (m == marker) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+
+/**
+ * Add a marker the cluster.
+ *
+ * @param {google.maps.Marker} marker The marker to add.
+ * @return {boolean} True if the marker was added.
+ */
+Cluster.prototype.addMarker = function(marker) {
+    if (this.isMarkerAlreadyAdded(marker)) {
+        return false;
+    }
+
+    if (!this.center_) {
+        this.center_ = marker.getPosition();
+        this.calculateBounds_();
+    } else {
+        if (this.averageCenter_) {
+            var l = this.markers_.length + 1;
+            var lat = (this.center_.lat() * (l - 1) + marker.getPosition().lat()) / l;
+            var lng = (this.center_.lng() * (l - 1) + marker.getPosition().lng()) / l;
+            this.center_ = new google.maps.LatLng(lat, lng);
+            this.calculateBounds_();
+        }
+    }
+
+    marker.isAdded = true;
+    this.markers_.push(marker);
+
+    var len = this.markers_.length;
+    if (len < this.minClusterSize_ && marker.getMap() != this.map_) {
+        // Min cluster size not reached so show the marker.
+        marker.setMap(this.map_);
+    }
+
+    if (len == this.minClusterSize_) {
+        // Hide the markers that were showing.
+        for (var i = 0; i < len; i++) {
+            this.markers_[i].setMap(null);
+        }
+    }
+
+    if (len >= this.minClusterSize_) {
+        marker.setMap(null);
+    }
+
+    this.updateIcon();
+    return true;
+};
+
+
+/**
+ * Returns the marker clusterer that the cluster is associated with.
+ *
+ * @return {MarkerClusterer} The associated marker clusterer.
+ */
+Cluster.prototype.getMarkerClusterer = function() {
+    return this.markerClusterer_;
+};
+
+
+/**
+ * Returns the bounds of the cluster.
+ *
+ * @return {google.maps.LatLngBounds} the cluster bounds.
+ */
+Cluster.prototype.getBounds = function() {
+    var bounds = new google.maps.LatLngBounds(this.center_, this.center_);
+    var markers = this.getMarkers();
+    for (var i = 0, marker; marker = markers[i]; i++) {
+        bounds.extend(marker.getPosition());
+    }
+    return bounds;
+};
+
+
+/**
+ * Removes the cluster
+ */
+Cluster.prototype.remove = function() {
+    this.clusterIcon_.remove();
+    this.markers_.length = 0;
+    delete this.markers_;
+};
+
+
+/**
+ * Returns the number of markers in the cluster.
+ *
+ * @return {number} The number of markers in the cluster.
+ */
+Cluster.prototype.getSize = function() {
+    return this.markers_.length;
+};
+
+
+/**
+ * Returns a list of the markers in the cluster.
+ *
+ * @return {Array.<google.maps.Marker>} The markers in the cluster.
+ */
+Cluster.prototype.getMarkers = function() {
+    return this.markers_;
+};
+
+
+/**
+ * Returns the center of the cluster.
+ *
+ * @return {google.maps.LatLng} The cluster center.
+ */
+Cluster.prototype.getCenter = function() {
+    return this.center_;
+};
+
+
+/**
+ * Calculated the extended bounds of the cluster with the grid.
+ *
+ * @private
+ */
+Cluster.prototype.calculateBounds_ = function() {
+    var bounds = new google.maps.LatLngBounds(this.center_, this.center_);
+    this.bounds_ = this.markerClusterer_.getExtendedBounds(bounds);
+};
+
+
+/**
+ * Determines if a marker lies in the clusters bounds.
+ *
+ * @param {google.maps.Marker} marker The marker to check.
+ * @return {boolean} True if the marker lies in the bounds.
+ */
+Cluster.prototype.isMarkerInClusterBounds = function(marker) {
+    return this.bounds_.contains(marker.getPosition());
+};
+
+
+/**
+ * Returns the map that the cluster is associated with.
+ *
+ * @return {google.maps.Map} The map.
+ */
+Cluster.prototype.getMap = function() {
+    return this.map_;
+};
+
+
+/**
+ * Updates the cluster icon
+ */
+Cluster.prototype.updateIcon = function() {
+    var zoom = this.map_.getZoom();
+    var mz = this.markerClusterer_.getMaxZoom();
+
+    if (mz && zoom > mz) {
+        // The zoom is greater than our max zoom so show all the markers in cluster.
+        for (var i = 0, marker; marker = this.markers_[i]; i++) {
+            marker.setMap(this.map_);
+        }
+        return;
+    }
+
+    if (this.markers_.length < this.minClusterSize_) {
+        // Min cluster size not yet reached.
+        this.clusterIcon_.hide();
+        return;
+    }
+
+    var numStyles = this.markerClusterer_.getStyles().length;
+    var sums = this.markerClusterer_.getCalculator()(this.markers_, numStyles);
+    this.clusterIcon_.setCenter(this.center_);
+    this.clusterIcon_.setSums(sums);
+    this.clusterIcon_.show();
+};
+
+
+/**
+ * A cluster icon
+ *
+ * @param {Cluster} cluster The cluster to be associated with.
+ * @param {Object} styles An object that has style properties:
+ *     'url': (string) The image url.
+ *     'height': (number) The image height.
+ *     'width': (number) The image width.
+ *     'anchor': (Array) The anchor position of the label text.
+ *     'textColor': (string) The text color.
+ *     'textSize': (number) The text size.
+ *     'backgroundPosition: (string) The background postition x, y.
+ * @param {number=} opt_padding Optional padding to apply to the cluster icon.
+ * @constructor
+ * @extends google.maps.OverlayView
+ * @ignore
+ */
+function ClusterIcon(cluster, styles, opt_padding) {
+    cluster.getMarkerClusterer().extend(ClusterIcon, google.maps.OverlayView);
+
+    this.styles_ = styles;
+    this.padding_ = opt_padding || 0;
+    this.cluster_ = cluster;
+    this.center_ = null;
+    this.map_ = cluster.getMap();
+    this.div_ = null;
+    this.sums_ = null;
+    this.visible_ = false;
+
+    this.setMap(this.map_);
+}
+
+
+/**
+ * Triggers the clusterclick event and zoom's if the option is set.
+ */
+ClusterIcon.prototype.triggerClusterClick = function() {
+    var markerClusterer = this.cluster_.getMarkerClusterer();
+
+    // Trigger the clusterclick event.
+    google.maps.event.trigger(markerClusterer.map_, 'clusterclick', this.cluster_);
+
+    if (markerClusterer.isZoomOnClick()) {
+        // Zoom into the cluster.
+        this.map_.fitBounds(this.cluster_.getBounds());
+    }
+};
+
+
+/**
+ * Adding the cluster icon to the dom.
+ * @ignore
+ */
+ClusterIcon.prototype.onAdd = function() {
+    this.div_ = document.createElement('DIV');
+    if (this.visible_) {
+        var pos = this.getPosFromLatLng_(this.center_);
+        this.div_.style.cssText = this.createCss(pos);
+        this.div_.innerHTML = this.sums_.text;
+    }
+
+    var panes = this.getPanes();
+    panes.overlayMouseTarget.appendChild(this.div_);
+
+    var that = this;
+    google.maps.event.addDomListener(this.div_, 'click', function() {
+        that.triggerClusterClick();
+    });
+};
+
+
+/**
+ * Returns the position to place the div dending on the latlng.
+ *
+ * @param {google.maps.LatLng} latlng The position in latlng.
+ * @return {google.maps.Point} The position in pixels.
+ * @private
+ */
+ClusterIcon.prototype.getPosFromLatLng_ = function(latlng) {
+    var pos = this.getProjection().fromLatLngToDivPixel(latlng);
+    pos.x -= parseInt(this.width_ / 2, 10);
+    pos.y -= parseInt(this.height_ / 2, 10);
+    return pos;
+};
+
+
+/**
+ * Draw the icon.
+ * @ignore
+ */
+ClusterIcon.prototype.draw = function() {
+    if (this.visible_) {
+        var pos = this.getPosFromLatLng_(this.center_);
+        this.div_.style.top = pos.y + 'px';
+        this.div_.style.left = pos.x + 'px';
+        this.div_.style.zIndex = google.maps.Marker.MAX_ZINDEX + 1;
+    }
+};
+
+
+/**
+ * Hide the icon.
+ */
+ClusterIcon.prototype.hide = function() {
+    if (this.div_) {
+        this.div_.style.display = 'none';
+    }
+    this.visible_ = false;
+};
+
+
+/**
+ * Position and show the icon.
+ */
+ClusterIcon.prototype.show = function() {
+    if (this.div_) {
+        var pos = this.getPosFromLatLng_(this.center_);
+        this.div_.style.cssText = this.createCss(pos);
+        this.div_.style.display = '';
+    }
+    this.visible_ = true;
+};
+
+
+/**
+ * Remove the icon from the map
+ */
+ClusterIcon.prototype.remove = function() {
+    this.setMap(null);
+};
+
+
+/**
+ * Implementation of the onRemove interface.
+ * @ignore
+ */
+ClusterIcon.prototype.onRemove = function() {
+    if (this.div_ && this.div_.parentNode) {
+        this.hide();
+        this.div_.parentNode.removeChild(this.div_);
+        this.div_ = null;
+    }
+};
+
+
+/**
+ * Set the sums of the icon.
+ *
+ * @param {Object} sums The sums containing:
+ *   'text': (string) The text to display in the icon.
+ *   'index': (number) The style index of the icon.
+ */
+ClusterIcon.prototype.setSums = function(sums) {
+    this.sums_ = sums;
+    this.text_ = sums.text;
+    this.index_ = sums.index;
+    if (this.div_) {
+        this.div_.innerHTML = sums.text;
+    }
+
+    this.useStyle();
+};
+
+
+/**
+ * Sets the icon to the the styles.
+ */
+ClusterIcon.prototype.useStyle = function() {
+    var index = Math.max(0, this.sums_.index - 1);
+    index = Math.min(this.styles_.length - 1, index);
+    var style = this.styles_[index];
+    this.url_ = style['url'];
+    this.height_ = style['height'];
+    this.width_ = style['width'];
+    this.textColor_ = style['textColor'];
+    this.anchor_ = style['anchor'];
+    this.textSize_ = style['textSize'];
+    this.backgroundPosition_ = style['backgroundPosition'];
+};
+
+
+/**
+ * Sets the center of the icon.
+ *
+ * @param {google.maps.LatLng} center The latlng to set as the center.
+ */
+ClusterIcon.prototype.setCenter = function(center) {
+    this.center_ = center;
+};
+
+
+/**
+ * Create the css text based on the position of the icon.
+ *
+ * @param {google.maps.Point} pos The position.
+ * @return {string} The css style text.
+ */
+ClusterIcon.prototype.createCss = function(pos) {
+    var style = [];
+    style.push('background-image:url(' + this.url_ + ');');
+    var backgroundPosition = this.backgroundPosition_ ? this.backgroundPosition_ : '0 0';
+    style.push('background-position:' + backgroundPosition + ';');
+
+    if (typeof this.anchor_ === 'object') {
+        if (typeof this.anchor_[0] === 'number' && this.anchor_[0] > 0 && this.anchor_[0] < this.height_) {
+            style.push('height:' + (this.height_ - this.anchor_[0]) + 'px; padding-top:' + this.anchor_[0] + 'px;');
+        } else {
+            style.push('height:' + this.height_ + 'px; line-height:' + this.height_ + 'px;');
+        }
+        if (typeof this.anchor_[1] === 'number' && this.anchor_[1] > 0 && this.anchor_[1] < this.width_) {
+            style.push('width:' + (this.width_ - this.anchor_[1]) + 'px; padding-left:' + this.anchor_[1] + 'px;');
+        } else {
+            style.push('width:' + this.width_ + 'px; text-align:center;');
+        }
+    } else {
+        style.push('height:' + this.height_ + 'px; line-height:' + this.height_ + 'px; width:' + this.width_ + 'px; text-align:center;');
+    }
+
+    var txtColor = this.textColor_ ? this.textColor_ : 'black';
+    var txtSize = this.textSize_ ? this.textSize_ : 11;
+
+    style.push('cursor:pointer; top:' + pos.y + 'px; left:' + pos.x + 'px; color:' + txtColor + '; position:absolute; font-size:' + txtSize + 'px; font-family:Arial,sans-serif; font-weight:bold');
+    return style.join('');
+};
+
+
+// Export Symbols for Closure
+// If you are not going to compile with closure then you can remove the
+// code below.
+window['MarkerClusterer'] = MarkerClusterer;
+MarkerClusterer.prototype['addMarker'] = MarkerClusterer.prototype.addMarker;
+MarkerClusterer.prototype['addMarkers'] = MarkerClusterer.prototype.addMarkers;
+MarkerClusterer.prototype['clearMarkers'] = MarkerClusterer.prototype.clearMarkers;
+MarkerClusterer.prototype['fitMapToMarkers'] = MarkerClusterer.prototype.fitMapToMarkers;
+MarkerClusterer.prototype['getCalculator'] = MarkerClusterer.prototype.getCalculator;
+MarkerClusterer.prototype['getGridSize'] = MarkerClusterer.prototype.getGridSize;
+MarkerClusterer.prototype['getExtendedBounds'] = MarkerClusterer.prototype.getExtendedBounds;
+MarkerClusterer.prototype['getMap'] = MarkerClusterer.prototype.getMap;
+MarkerClusterer.prototype['getMarkers'] = MarkerClusterer.prototype.getMarkers;
+MarkerClusterer.prototype['getMaxZoom'] = MarkerClusterer.prototype.getMaxZoom;
+MarkerClusterer.prototype['getStyles'] = MarkerClusterer.prototype.getStyles;
+MarkerClusterer.prototype['getTotalClusters'] = MarkerClusterer.prototype.getTotalClusters;
+MarkerClusterer.prototype['getTotalMarkers'] = MarkerClusterer.prototype.getTotalMarkers;
+MarkerClusterer.prototype['redraw'] = MarkerClusterer.prototype.redraw;
+MarkerClusterer.prototype['removeMarker'] = MarkerClusterer.prototype.removeMarker;
+MarkerClusterer.prototype['removeMarkers'] = MarkerClusterer.prototype.removeMarkers;
+MarkerClusterer.prototype['resetViewport'] = MarkerClusterer.prototype.resetViewport;
+MarkerClusterer.prototype['repaint'] = MarkerClusterer.prototype.repaint;
+MarkerClusterer.prototype['setCalculator'] = MarkerClusterer.prototype.setCalculator;
+MarkerClusterer.prototype['setGridSize'] = MarkerClusterer.prototype.setGridSize;
+MarkerClusterer.prototype['setMaxZoom'] = MarkerClusterer.prototype.setMaxZoom;
+MarkerClusterer.prototype['onAdd'] = MarkerClusterer.prototype.onAdd;
+MarkerClusterer.prototype['draw'] = MarkerClusterer.prototype.draw;
+
+Cluster.prototype['getCenter'] = Cluster.prototype.getCenter;
+Cluster.prototype['getSize'] = Cluster.prototype.getSize;
+Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
+
+ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
+ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
+ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
+
+Object.keys = Object.keys || function(o) {
+    var result = [];
+    for (var name in o) {
+        if (o.hasOwnProperty(name)) result.push(name);
+    }
+    return result;
+};

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -77,11 +77,16 @@
                 var innerTemplate = $('#member-item-template').html();
                 var outerTemplate = $('#members-template').html();
 
-                var multiHtml = Mustache.render(outerTemplate, data, {
-                    member: innerTemplate
-                });
+                var multiHtml = Mustache.render(outerTemplate,
+                    data,
+                    {
+                        member: innerTemplate
+                    });
 
                 $("#member-list").html(multiHtml);
+            } else {
+                //Ensure the member list is cleared out - when we zoom out we need to clear out our results
+                $("#member-list").html("");
             }
 
         });

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -2,9 +2,26 @@
 
     var map = new google.maps.Map(document.getElementById('map'),
         {
-            zoom: 2,
+            zoom: 5,
             center: { lat: 0, lng: 0 }
         });
+
+    // Try HTML5 geolocation.
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(function (position) {            
+            var pos = {
+                lat: position.coords.latitude,
+                lng: position.coords.longitude
+            };
+
+            //Use the lat & lon of the users current location
+            //To set the center of the map
+            map.setCenter(pos);
+
+        }, function () {
+            //If we ever need todo handle error handling - or user denined permission
+        });
+    }
 
     // Add some markers to the map.
     // Note: The code uses the JavaScript Array.prototype.map() method to

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -1,0 +1,29 @@
+﻿function initMap() {
+
+    var map = new google.maps.Map(document.getElementById('map'),
+        {
+            zoom: 2,
+            center: { lat: 0, lng: 0 }
+        });
+
+    // Add some markers to the map.
+    // Note: The code uses the JavaScript Array.prototype.map() method to
+    // create an array of markers based on a given "locations" array.
+    // The map() method here has nothing to do with the Google Maps API.
+    $.getJSON("/umbraco/api/mapapi/GetAllMemberLocations", function(data) {
+
+        var markers = data.map(function(item) {
+            var latlng = new google.maps.LatLng(item.Lat, item.Lon);
+            return new google.maps.Marker({
+                position: latlng
+            });
+        });
+
+        // Add a marker clusterer to manage the markers.
+        var markerCluster = new MarkerClusterer(map,
+            markers,
+            {
+                imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'
+            });
+    });
+};

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -23,38 +23,43 @@
         });
     }
 
-    // Add some markers to the map.
-    // Note: The code uses the JavaScript Array.prototype.map() method to
-    // create an array of markers based on a given "locations" array.
-    // The map() method here has nothing to do with the Google Maps API.
-    $.getJSON("/umbraco/api/mapapi/GetAllMemberLocations", function(data) {
+    google.maps.event.addListener(map, 'idle', () => {
+        const sw = map.getBounds().getSouthWest();
+        const ne = map.getBounds().getNorthEast();
         
-        var markers = data.map(function(item) {
-            var latlng = new google.maps.LatLng(item.Lat, item.Lon);
-            var marker = new google.maps.Marker({
-                position: latlng
+        var url = "/umbraco/api/mapapi/GetAllMemberLocations?swLat=" + sw.lat() + "&swLon=" + sw.lng() + "&neLat=" + ne.lat() + "&neLon=" + ne.lng();
+
+        $.getJSON(url, function (data) {
+
+            var markers = data.map(function (item) {
+                var latlng = new google.maps.LatLng(item.Lat, item.Lon);
+                var marker = new google.maps.Marker({
+                    position: latlng
+                });
+
+                var infowindow = new google.maps.InfoWindow({
+                    content: "<span>Loading</span>"
+                });
+
+                //Only render the HTML content - when you click the marker
+                var html = "<a href='/member/" + item.Id + "' style='display:flex; align-items:center;'><img src='" + item.Avatar + "' title='" + item.Name + "' style='margin-right:5px;'/>" + item.Name + "</a>";
+
+                marker.addListener('click', function () {
+                    infowindow.setContent(html);
+                    infowindow.open(map, marker);
+                });
+
+                return marker;
             });
 
-            var infowindow = new google.maps.InfoWindow({
-                content: "<span>Loading</span>"
-            });
+            // Add a marker clusterer to manage the markers.
+            var markerCluster = new MarkerClusterer(map,
+                markers,
+                {
+                    imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'
+                });
 
-            //Only render the HTML content - when you click the marker
-            var html = "<a href='/member/" + item.Id + "' style='display:flex; align-items:center;'><img src='" + item.Avatar + "' title='" + item.Name + "' style='margin-right:5px;'/>" + item.Name + "</a>";
-
-            marker.addListener('click', function () {
-                infowindow.setContent(html);
-                infowindow.open(map, marker);
-            });
-
-            return marker;
         });
 
-        // Add a marker clusterer to manage the markers.
-        var markerCluster = new MarkerClusterer(map,
-            markers,
-            {
-                imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'
-            });
     });
 };

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -11,12 +11,22 @@
     // create an array of markers based on a given "locations" array.
     // The map() method here has nothing to do with the Google Maps API.
     $.getJSON("/umbraco/api/mapapi/GetAllMemberLocations", function(data) {
-
+        
         var markers = data.map(function(item) {
             var latlng = new google.maps.LatLng(item.Lat, item.Lon);
-            return new google.maps.Marker({
+            var marker = new google.maps.Marker({
                 position: latlng
             });
+
+            var infowindow = new google.maps.InfoWindow({
+                content: "<a href='/member/" + item.Id + "' style='display:flex; align-items:center;'><img src='" + item.Avatar +"' title='" + item.Name + "' style='margin-right:5px;'/>" + item.Name + "</a>"
+            });
+
+            marker.addListener('click', function() {
+                infowindow.open(map, marker);
+            });
+
+            return marker;
         });
 
         // Add a marker clusterer to manage the markers.

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -3,7 +3,7 @@
     var map = new google.maps.Map(document.getElementById('map'),
         {
             zoom: 5,
-            center: { lat: 0, lng: 0 }
+            center: { lat: 51.4472452, lng: 2.8123371 }
         });
 
     // Try HTML5 geolocation.
@@ -15,8 +15,9 @@
             };
 
             //Use the lat & lon of the users current location
-            //To set the center of the map
+            //To set the center of the map and zoom in closer
             map.setCenter(pos);
+            map.setZoom(8);
 
         }, function () {
             //If we ever need todo handle error handling - or user denined permission

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -30,6 +30,9 @@
         
         var url = "/umbraco/api/mapapi/GetAllMemberLocations?swLat=" + sw.lat() + "&swLon=" + sw.lng() + "&neLat=" + ne.lat() + "&neLon=" + ne.lng();
 
+        //Map Marker mustache HTML template
+        var template = $('#map-marker-template').html();
+
         $.getJSON(url, function (data) {
 
             var markers = data.map(function (item) {
@@ -43,7 +46,7 @@
                 });
 
                 //Only render the HTML content - when you click the marker
-                var html = "<a href='/member/" + item.Id + "' style='display:flex; align-items:center;'><img src='" + item.Avatar + "' title='" + item.Name + "' style='margin-right:5px;'/>" + item.Name + "</a>";
+                var html = Mustache.render(template, item);
 
                 marker.addListener('click', function () {
                     infowindow.setContent(html);
@@ -60,6 +63,15 @@
                     imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'
                 });
 
+
+            //If the zoom level greater than 18
+            //Server finds exact matches on lat & lon & returns bool 'SomeoneElseIsHere' in JSON payload
+            //This way we can show only people who are under same pin
+            //HOWEVER there is a case lat/lon no exact but insanely close & even at max zoom the cluster
+            //Will group it under the same lat/lon
+            //Maybe if we are at max zoom level & have results - list them all
+            //The zoom level service requires a lat/lon - get the map center lat/lon
+            console.log('zoom level', map.getZoom());
         });
 
     });

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -71,7 +71,19 @@
             //Will group it under the same lat/lon
             //Maybe if we are at max zoom level & have results - list them all
             //The zoom level service requires a lat/lon - get the map center lat/lon
-            console.log('zoom level', map.getZoom());
+            var zoomLevel = map.getZoom();
+            if (zoomLevel > 18) {
+
+                var innerTemplate = $('#member-item-template').html();
+                var outerTemplate = $('#members-template').html();
+
+                var multiHtml = Mustache.render(outerTemplate, data, {
+                    member: innerTemplate
+                });
+
+                $("#member-list").html(multiHtml);
+            }
+
         });
 
     });

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -63,16 +63,8 @@
                     imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'
                 });
 
-
-            //If the zoom level greater than 18
-            //Server finds exact matches on lat & lon & returns bool 'SomeoneElseIsHere' in JSON payload
-            //This way we can show only people who are under same pin
-            //HOWEVER there is a case lat/lon no exact but insanely close & even at max zoom the cluster
-            //Will group it under the same lat/lon
-            //Maybe if we are at max zoom level & have results - list them all
-            //The zoom level service requires a lat/lon - get the map center lat/lon
             var zoomLevel = map.getZoom();
-            if (zoomLevel > 18) {
+            if (zoomLevel > 15) {
 
                 var innerTemplate = $('#member-item-template').html();
                 var outerTemplate = $('#members-template').html();

--- a/OurUmbraco.Site/Assets/js/map/community.map.js
+++ b/OurUmbraco.Site/Assets/js/map/community.map.js
@@ -19,10 +19,14 @@
             });
 
             var infowindow = new google.maps.InfoWindow({
-                content: "<a href='/member/" + item.Id + "' style='display:flex; align-items:center;'><img src='" + item.Avatar +"' title='" + item.Name + "' style='margin-right:5px;'/>" + item.Name + "</a>"
+                content: "<span>Loading</span>"
             });
 
-            marker.addListener('click', function() {
+            //Only render the HTML content - when you click the marker
+            var html = "<a href='/member/" + item.Id + "' style='display:flex; align-items:center;'><img src='" + item.Avatar + "' title='" + item.Name + "' style='margin-right:5px;'/>" + item.Name + "</a>";
+
+            marker.addListener('click', function () {
+                infowindow.setContent(html);
                 infowindow.open(map, marker);
             });
 

--- a/OurUmbraco.Site/Assets/js/map/profile.map.js
+++ b/OurUmbraco.Site/Assets/js/map/profile.map.js
@@ -1,0 +1,98 @@
+﻿function initMap() {
+    
+    //Default position at Umbraco HQ
+    var userPosition = {
+        lat: 55.4063542,
+        lng: 10.3862208
+    }
+
+    var createInitUserMarker = false;
+    
+    var currentLat = document.getElementById("Latitude").value;
+    var currentLon = document.getElementById("Longitude").value;
+    
+    var mapObj = new google.maps.Map(document.getElementById('profile-map'),
+        {
+            zoom: 14,
+            center: userPosition,
+            mapTypeId: 'roadmap'
+        });
+
+    console.log('currentLat', currentLat);
+    console.log('currentLon', currentLon);
+    console.log('lat has val', (currentLat.length > 0));
+    console.log('lon has val', (currentLon.length > 0));
+
+    //Check we have something stored in hidden fields & valid numbers
+    if ((currentLat.length > 0) || (currentLon.length > 0)) {
+
+        if (isNaN(currentLat) === false || isNaN(currentLon) === false) {
+
+            userPosition.lat = Number(currentLat);
+            userPosition.lng = Number(currentLon);
+
+            createInitUserMarker = true;
+
+        } else {
+            alert('bad data & not a number');
+
+            //Lets clean up & set empty values in the hidden fields - so we dont carry on having rubbish data
+            document.getElementById("Latitude").value = "";
+            document.getElementById("Longitude").value = "";
+        }
+    }
+    
+    //Use the lat & lon of the user (stored location or the fallaback of HQ)
+    mapObj.setCenter(userPosition);
+
+    var marker = new google.maps.Marker({
+        draggable: true
+    });
+
+    //The init marker add to the map or when its dragged will invoke us updating the hidden textboxes
+    marker.addListener('position_changed', function () {
+
+        var newPosition = marker.getPosition();
+        document.getElementById("Latitude").value = newPosition.lat();
+        document.getElementById("Longitude").value = newPosition.lng();
+    });
+    
+    if (createInitUserMarker) {
+
+        //We update the marker with the position & add it onto the map
+        marker.setPosition(userPosition);
+        marker.setMap(mapObj);
+    }
+
+    //Clear/remove marker button
+    document.getElementById("remove-me").addEventListener("click", function () {
+        document.getElementById("Latitude").value = "";
+        document.getElementById("Longitude").value = "";
+        marker.setMap(null);
+    });
+
+
+    //Geo locate me button
+    document.getElementById("geolocate-me").addEventListener("click", function () {
+        
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition(function(geoPosition) {
+                var pos = {
+                    lat: geoPosition.coords.latitude,
+                    lng: geoPosition.coords.longitude
+                };
+
+                //We don't explicitly set the input fields - as the marker event will trigger updating them
+                marker.setPosition(pos);
+                marker.setMap(mapObj);
+                mapObj.setCenter(pos);
+
+            },
+            function() {
+                alert('There was an error trying to find you. Perhaps you denied us permission?');
+            });
+        } else {
+            alert('Your browser does not support HTML5 GeoLocation');
+        }
+    });
+}

--- a/OurUmbraco.Site/Assets/js/map/profile.map.js
+++ b/OurUmbraco.Site/Assets/js/map/profile.map.js
@@ -17,12 +17,7 @@
             center: userPosition,
             mapTypeId: 'roadmap'
         });
-
-    console.log('currentLat', currentLat);
-    console.log('currentLon', currentLon);
-    console.log('lat has val', (currentLat.length > 0));
-    console.log('lon has val', (currentLon.length > 0));
-
+    
     //Check we have something stored in hidden fields & valid numbers
     if ((currentLat.length > 0) || (currentLon.length > 0)) {
 

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -459,6 +459,7 @@
     <Content Include="Assets\js\lib\svg4everybody.min.js" />
     <Content Include="Assets\js\lodash.min.js" />
     <Content Include="Assets\js\map\community.map.js" />
+    <Content Include="Assets\js\map\profile.map.js" />
     <Content Include="Assets\swipebox\css\swipebox.css" />
     <Content Include="Assets\swipebox\css\swipebox.min.css" />
     <Content Include="Assets\swipebox\img\icons.png" />

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -452,6 +452,7 @@
     <Content Include="Assets\js\gitter\gitter.signalr.js" />
     <Content Include="Assets\js\jquery.ajaxfileupload.js" />
     <Content Include="Assets\js\lib\emojione.min.js" />
+    <Content Include="Assets\js\lib\markerclusterer.js" />
     <Content Include="Assets\js\lib\svg4everybody.min.js" />
     <Content Include="Assets\js\lodash.min.js" />
     <Content Include="Assets\swipebox\css\swipebox.css" />
@@ -4380,6 +4381,7 @@
     <Content Include="Views\Partials\Grid\Bootstrap3-Fluid.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap2.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap2-Fluid.cshtml" />
+    <Content Include="Views\Partials\Community\Map.cshtml" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -455,6 +455,7 @@
     <Content Include="Assets\js\lib\markerclusterer.js" />
     <Content Include="Assets\js\lib\svg4everybody.min.js" />
     <Content Include="Assets\js\lodash.min.js" />
+    <Content Include="Assets\js\map\community.map.js" />
     <Content Include="Assets\swipebox\css\swipebox.css" />
     <Content Include="Assets\swipebox\css\swipebox.min.css" />
     <Content Include="Assets\swipebox\img\icons.png" />

--- a/OurUmbraco.Site/Views/Partials/Community/Hub.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Hub.cshtml
@@ -3,12 +3,13 @@
 @inherits OurUmbracoTemplatePage
 
 @*@GitHubMatch()*@
+@Html.Partial("Community/Map")
 
-@Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/playground" })
+@*@Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/playground" })
 @Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/another-testing-room" })
 @Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/Umbraco-CMS" })
 @Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/OurUmbraco" })
-@Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/Umbraco-Community" })
+@Html.Action("RenderGitterRoom", "GitterRoomSurface", new { roomName = "umbraco/Umbraco-Community" })*@
 
 @helper GitHubMatch()
 {

--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -23,10 +23,9 @@
     <div style="display:flex; align-items:center;">
         <img src="{{Avatar}}" title="{{Name}}" style="margin-right:5px; border-radius:50%;" />
         
-        <div style="">
-            <a href="/member/{{Id}}">
-                {{Name}}
-            </a>
+        <div>
+            <a href="/member/{{Id}}">{{Name}}</a>
+            <em>Karma: {{Karma}}</em>
 
             <div class="social-links">
                 {{#Twitter}}
@@ -35,12 +34,12 @@
                     <span>{{Twitter}}</span>
                 </a>
                 {{/Twitter}}
-                {{#Github}}
+                {{#GitHub}}
                 <a href="https://github.com/{{Github}}" title="See {{Name}}'s profile on GitHub" target="_blank" rel="noopener">
                     <i class="icon-github" aria-hidden="true"></i>
-                    <span>{{Github}}</span>
+                    <span>{{GitHub}}</span>
                 </a>
-                {{/Github}}
+                {{/GitHub}}
             </div>
         </div>
     </div>

--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -17,6 +17,8 @@
 
 <h1>Map</h1>
 <div id="map"></div>
+<div id="member-list" style="margin-top: 25px;"></div>
+
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=@(apiKey)&callback=initMap"></script>
 
 <script id="map-marker-template" type="x-tmpl-mustache">
@@ -48,14 +50,36 @@
 
 <script id="members-template" type="x-tmpl-mustache">
     <h3>There are quite a few people at this location</h3>
-    <div class="map-members">
-        {{#members}}
-        {{>.}}
-        {{/members}}
+    <div style="display:flex; flex-direction:row; flex-wrap:wrap; justify-content:space-between;">
+        {{ #. }}
+        {{ >member }}
+        {{ /. }}
     </div>    
 </script>
 
 <script id="member-item-template" type="x-tmpl-mustache">
-    Hello {{ name }}!
+    <div style="border:1px solid grey; display:flex; padding:5px; flex-grow: 1; flex-shrink: 0; flex-basis: 40%; margin-right:5px; margin-bottom:5px; align-items:center;">
+        <img src="{{Avatar}}" title="{{Name}}" style="margin-right:5px; border-radius:50%;" />
+        
+        <div>
+            <a href="/member/{{Id}}">{{Name}}</a>
+            <em>Karma: {{Karma}}</em>
+
+            <div class="social-links">
+                {{#Twitter}}
+                <a href="https://twitter.com/{{Twitter}}" title="See {{Name}}'s profile on Twitter" target="_blank" rel="noopener">
+                    <i class="icon-twitter" aria-hidden="true"></i>
+                    <span>{{Twitter}}</span>
+                </a>
+                {{/Twitter}}
+                {{#GitHub}}
+                <a href="https://github.com/{{Github}}" title="See {{Name}}'s profile on GitHub" target="_blank" rel="noopener">
+                    <i class="icon-github" aria-hidden="true"></i>
+                    <span>{{GitHub}}</span>
+                </a>
+                {{/GitHub}}
+            </div>
+        </div>
+    </div>
 </script>
 

--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -1,0 +1,55 @@
+﻿@using ClientDependency.Core.Mvc
+@{
+    Html.RequiresJs("~/assets/js/lib/markerclusterer.js");
+    var apiKey = "AIzaSyCyVUmjYOjblvpPIE9Qqhz1yjLp3HzKnC4";
+}
+
+<style>
+    /* Always set the map height explicitly to define the size of the div
+    * element that contains the map. */
+     #map {
+         min-height: 500px;
+     }
+</style>
+
+<h1>Map</h1>
+<div id="map"></div>
+<script>
+
+      function initMap() {
+
+        var map = new google.maps.Map(document.getElementById('map'), {
+          zoom: 2,
+          center: {lat: 0, lng:0}
+        });
+        
+        // Add some markers to the map.
+        // Note: The code uses the JavaScript Array.prototype.map() method to
+        // create an array of markers based on a given "locations" array.
+        // The map() method here has nothing to do with the Google Maps API.
+
+        
+          $.getJSON("/umbraco/api/mapapi/GetAllMemberLocations", function(data) {
+              console.log('data', data);
+              console.log('length', data.length);
+
+              var markers = data.map(function(item) {
+                  
+                  var latlng = new google.maps.LatLng(item.Lat, item.Lon);
+                    return new google.maps.Marker({
+                      position: latlng
+                  });
+              });
+
+              // Add a marker clusterer to manage the markers.
+              var markerCluster = new MarkerClusterer(map, markers,
+                  {imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'});
+          });
+
+
+       
+
+        
+      }
+</script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key=@(apiKey)&callback=initMap"></script>

--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -18,3 +18,45 @@
 <h1>Map</h1>
 <div id="map"></div>
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=@(apiKey)&callback=initMap"></script>
+
+<script id="map-marker-template" type="x-tmpl-mustache">
+    <div style="display:flex; align-items:center;">
+        <img src="{{Avatar}}" title="{{Name}}" style="margin-right:5px; border-radius:50%;" />
+        
+        <div style="">
+            <a href="/member/{{Id}}">
+                {{Name}}
+            </a>
+
+            <div class="social-links">
+                {{#Twitter}}
+                <a href="https://twitter.com/{{Twitter}}" title="See {{Name}}'s profile on Twitter" target="_blank" rel="noopener">
+                    <i class="icon-twitter" aria-hidden="true"></i>
+                    <span>{{Twitter}}</span>
+                </a>
+                {{/Twitter}}
+                {{#Github}}
+                <a href="https://github.com/{{Github}}" title="See {{Name}}'s profile on GitHub" target="_blank" rel="noopener">
+                    <i class="icon-github" aria-hidden="true"></i>
+                    <span>{{Github}}</span>
+                </a>
+                {{/Github}}
+            </div>
+        </div>
+    </div>
+</script>
+
+
+<script id="members-template" type="x-tmpl-mustache">
+    <h3>There are quite a few people at this location</h3>
+    <div class="map-members">
+        {{#members}}
+        {{>.}}
+        {{/members}}
+    </div>    
+</script>
+
+<script id="member-item-template" type="x-tmpl-mustache">
+    Hello {{ name }}!
+</script>
+

--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -1,6 +1,9 @@
 ﻿@using ClientDependency.Core.Mvc
 @{
     Html.RequiresJs("~/assets/js/lib/markerclusterer.js");
+    Html.RequiresJs("~/assets/js/map/community.map.js");
+
+    //Google Maps API Key
     var apiKey = "AIzaSyCyVUmjYOjblvpPIE9Qqhz1yjLp3HzKnC4";
 }
 
@@ -14,42 +17,4 @@
 
 <h1>Map</h1>
 <div id="map"></div>
-<script>
-
-      function initMap() {
-
-        var map = new google.maps.Map(document.getElementById('map'), {
-          zoom: 2,
-          center: {lat: 0, lng:0}
-        });
-        
-        // Add some markers to the map.
-        // Note: The code uses the JavaScript Array.prototype.map() method to
-        // create an array of markers based on a given "locations" array.
-        // The map() method here has nothing to do with the Google Maps API.
-
-        
-          $.getJSON("/umbraco/api/mapapi/GetAllMemberLocations", function(data) {
-              console.log('data', data);
-              console.log('length', data.length);
-
-              var markers = data.map(function(item) {
-                  
-                  var latlng = new google.maps.LatLng(item.Lat, item.Lon);
-                    return new google.maps.Marker({
-                      position: latlng
-                  });
-              });
-
-              // Add a marker clusterer to manage the markers.
-              var markerCluster = new MarkerClusterer(map, markers,
-                  {imagePath: 'https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m'});
-          });
-
-
-       
-
-        
-      }
-</script>
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=@(apiKey)&callback=initMap"></script>

--- a/OurUmbraco.Site/Views/Partials/Members/Profile.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/Profile.cshtml
@@ -106,8 +106,8 @@
                 
                 <div>
                     <!--TODO: Decide if we display these (so user can see their saved data, or to set these as hidden fields -->
-                    <input id="Latitude" name="Latitude" type="text" disabled value="@Model.Latitude" />
-                    <input id="Longitude" name="Longitude" type="text" disabled value="@Model.Longitude" />
+                    @Html.HiddenFor(m => m.Latitude)
+                    @Html.HiddenFor(m => m.Longitude)
                 </div>
             </div>
 

--- a/OurUmbraco.Site/Views/Partials/Members/Profile.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/Profile.cshtml
@@ -1,14 +1,20 @@
-﻿@using OurUmbraco.Our
+﻿@using ClientDependency.Core.Mvc
+@using OurUmbraco.Our
 @using OurUmbraco.Our.Controllers
 
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<OurUmbraco.Our.Models.ProfileModel>
 @{
     Html.EnableClientValidation(true);
     Html.EnableUnobtrusiveJavaScript(true);
+
+    Html.RequiresJs("~/Assets/js/map/profile.map.js");
+
+    //Google Maps API Key
+    var apiKey = "AIzaSyCyVUmjYOjblvpPIE9Qqhz1yjLp3HzKnC4";
 }
 
-
- <div id="update-avatar-dialog" class="community-dialog">
+<!-- Modal for file upload -->
+<div id="update-avatar-dialog" class="community-dialog">
     <div>
         <p><b>Upload avatar</b></p>
         <p class="invalid-file">The select file type is invalid. File must be gif, png, jpg, jpeg.</p>
@@ -19,84 +25,105 @@
     </div>
 </div>
 
-    <div class="profile-settings">
-        <strong>Change your profile</strong>
-        <div class="profile-settings-forms">
+<div class="profile-settings">
+    <strong>Change your profile</strong>
+    <div class="profile-settings-forms">
 
-            @using (Html.BeginUmbracoForm<ProfileController>("HandleSubmit"))
-            {
-                @Html.ValidationSummary()
-                @Html.AntiForgeryToken()
+        @using (Html.BeginUmbracoForm<ProfileController>("HandleSubmit"))
+        {
+            @Html.ValidationSummary()
+            @Html.AntiForgeryToken()
 
-                <div class="avatar" id="avatar">
-                    <label for="avatar">
-                        Avatar
-                    </label>
+            <div class="avatar" id="avatar">
+                <label for="avatar">
+                    Avatar
+                </label>
 
-                    <div class="avatar-image inked">
-                        @Html.Raw(Utils.GetLocalAvatar(Model.Avatar ?? "", 100, ""))
-                        <span>Change image</span>
-                    </div>
-                    @Html.HiddenFor(m => m.Avatar)
+                <div class="avatar-image inked">
+                    @Html.Raw(Utils.GetLocalAvatar(Model.Avatar ?? "", 100, ""))
+                    <span>Change image</span>
                 </div>
+                @Html.HiddenFor(m => m.Avatar)
+            </div>
 
-                <div class="profile-input" id="username">
-                    @Html.LabelFor(m => m.Name)
-                    @Html.TextBoxFor(m => m.Name)
-                </div>
+            <div class="profile-input" id="username">
+                @Html.LabelFor(m => m.Name)
+                @Html.TextBoxFor(m => m.Name)
+            </div>
 
-                <div class="profile-input" id="email">
-                    @Html.LabelFor(m => m.Email)
-                    @Html.TextBoxFor(m => m.Email)
-                </div>
+            <div class="profile-input" id="email">
+                @Html.LabelFor(m => m.Email)
+                @Html.TextBoxFor(m => m.Email)
+            </div>
 
-                <div class="profile-input" id="password">
-                    @Html.LabelFor(m => m.Password)
-                    @Html.PasswordFor(m => m.Password, new { @class = "password-input" })
-                </div>
+            <div class="profile-input" id="password">
+                @Html.LabelFor(m => m.Password)
+                @Html.PasswordFor(m => m.Password, new { @class = "password-input" })
+            </div>
 
-                <div class="profile-input confirm-password" id="repeat-password">
-                    @Html.LabelFor(m => m.RepeatPassword)
-                    @Html.PasswordFor(m => m.RepeatPassword, new {@class = "password-input"})
-                </div>
+            <div class="profile-input confirm-password" id="repeat-password">
+                @Html.LabelFor(m => m.RepeatPassword)
+                @Html.PasswordFor(m => m.RepeatPassword, new {@class = "password-input"})
+            </div>
 
-                <div class="profile-input" id="company">
-                    @Html.LabelFor(m => m.Company)
-                    @Html.TextBoxFor(m => m.Company)
-                </div>
+            <div class="profile-input" id="company">
+                @Html.LabelFor(m => m.Company)
+                @Html.TextBoxFor(m => m.Company)
+            </div>
 
-                <div class="profile-input" id="bio">
-                    @Html.LabelFor(m => m.Bio)
-                    @Html.TextAreaFor(m => m.Bio)
-                </div>
+            <div class="profile-input" id="bio">
+                @Html.LabelFor(m => m.Bio)
+                @Html.TextAreaFor(m => m.Bio)
+            </div>
 
-                <div class="profile-input" id="twitter-alias">
-                    @Html.LabelFor(m => m.TwitterAlias)
-                    @Html.TextBoxFor(m => m.TwitterAlias)
-                </div>
+            <div class="profile-input" id="twitter-alias">
+                @Html.LabelFor(m => m.TwitterAlias)
+                @Html.TextBoxFor(m => m.TwitterAlias)
+            </div>
 
-                <div class="profile-input" id="github-alias">
-                    @Html.LabelFor(m => m.GitHubUsername)
-                    @Html.TextBoxFor(m => m.GitHubUsername)
-                </div>
+            <div class="profile-input" id="github-alias">
+                @Html.LabelFor(m => m.GitHubUsername)
+                @Html.TextBoxFor(m => m.GitHubUsername)
+            </div>
 
-                <div class="profile-input" id="located-at">
-                    @Html.LabelFor(m => m.Location)
-                    @Html.TextBoxFor(m => m.Location)
-                </div>
-
-                <input class="button green" type="submit" value="Save changes">
+            <div>
+                <h3>Map</h3>
+                <p>
+                    This information is optional but allows you to share your rough location on a community map,
+                    in order to see the sense of scale of the Umbraco community and other members near by.
+                </p>
+                <p>
+                    <em>It is your responsibility</em> to share your location & we strongly recommend you do
+                    not place a map marker to an exact location to protect yourself.
+                </p>
+                    
+                <div id="profile-map" style="min-height: 500px;"></div>
                 
-                if (TempData["success"] != null)
-                {
-                    <small class="notification success">
-                        Changes saved
-                    </small>
-                }
+                <div>
+                    <span class="button" id="geolocate-me">Use my geo location</span>
+                    <span class="button red disabled" id="remove-me">Clear my location</span>
+                </div>
+                
+                <div>
+                    <!--TODO: Decide if we display these (so user can see their saved data, or to set these as hidden fields -->
+                    <input id="Latitude" name="Latitude" type="text" disabled value="@Model.Latitude" />
+                    <input id="Longitude" name="Longitude" type="text" disabled value="@Model.Longitude" />
+                </div>
+            </div>
 
+            <input class="button green" type="submit" value="Save changes">
+                
+            if (TempData["success"] != null)
+            {
+                <small class="notification success">
+                    Changes saved
+                </small>
             }
 
-        </div>
-    </div>
+        }
 
+    </div>
+</div>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=@(apiKey)&callback=initMap" async defer></script>
 

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Web.Mvc;
 using Examine;
@@ -10,18 +11,32 @@ namespace OurUmbraco.Community.Map
 {
     public class MapApiController : UmbracoApiController
     {
+        //swLat= 44.255278708039896
+        //neLat= 51.599464320768725
+
+        //swLon= -142.07023127555988
+        //neLon= -124.49210627555988
+
         [HttpGet]
-        public List<MemberLocation> GetAllMemberLocations()
-        { 
+        public List<MemberLocation> GetAllMemberLocations(string swLat, string swLon, string neLat, string neLon)
+        {           
             var memberSearcher = ExamineManager.Instance.SearchProviderCollection["InternalMemberSearcher"];
             var searchCritera = memberSearcher.CreateSearchCriteria(IndexTypes.Member);
 
+            var longSwLat = Convert.ToDouble(swLat);
+            var longSwLon = Convert.ToDouble(swLon);
+            var longNeLat = Convert.ToDouble(neLat);
+            var longNeLon = Convert.ToDouble(neLon);
+            
             //Find all active members - where a lat & lon is set (with new NodeGathering field to index)
             var query = searchCritera.Field("hasLocationSet", "1")
                 .And().Field("blocked", "0")
-                .And().Field("umbracoMemberApproved", "1")
-                .Not().Range("karma", 0, 70, true, true); //Does not have karma points in between 0 to 70 (So must be over 70 then)
-            
+                .And().Field("umbracoMemberApproved", "1")                
+                .And().Range("latitudeNumber", longSwLat, longNeLat, true, true)
+                .And().Range("longitudeNumber", longSwLat, longNeLat, true, true)
+                .Not().Range("karma", 0, 70, true, true);
+
+
             var results = memberSearcher.Search(query.Compile());
 
             //Pluck the fields we need from the Examine index fields

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using System.Web.Mvc;
+using Examine;
+using Umbraco.Web.WebApi;
+using UmbracoExamine;
+
+namespace OurUmbraco.Community.Map
+{
+    public class MapApiController : UmbracoApiController
+    {
+        [HttpGet ]
+        public ISearchResults GetAllMemberLocations()
+        { 
+            var memberSearcher = ExamineManager.Instance.SearchProviderCollection["InternalMemberSearcher"];
+            var query = memberSearcher.CreateSearchCriteria(IndexTypes.Member);
+
+            //Find all active members - where a lat & lon is set (with new NodeGathering field to index)
+            query.Field("hasLocationSet", "1");
+
+                /*
+                .And().Field("blocked", "0")
+                .And().Field("umbracoMemberApproved ", "1").Compile();
+                */
+
+            //Query
+            var results = memberSearcher.Search(query);
+
+            var rawQuery = query.ToString();
+            return results;
+        }
+
+    }
+}

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -31,7 +31,9 @@ namespace OurUmbraco.Community.Map
             {
                 Name = result.Fields["nodeName"],
                 Lat = result.Fields["latitude"],
-                Lon = result.Fields["longitude"]
+                Lon = result.Fields["longitude"],
+                Avatar = result.Fields["avatar"],
+                Id = result.Id
             })
             .ToList();
             

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -42,8 +42,8 @@ namespace OurUmbraco.Community.Map
                 Id = result.Id,
                 Name = result.Fields["nodeName"],
                 Avatar = GetAvatar(result),
-                Lat = result.Fields["latitude"],
-                Lon = result.Fields["longitude"],
+                Lat = GetLatitude(result),
+                Lon = GetLongitude(result),
                 Karma = Convert.ToInt32(result.Fields[LuceneIndexer.SortedFieldNamePrefix + "karma"]), //Have to access the value as the raw field name with the magic string prefix
                 Twitter = GetTwitter(result),
                 GitHub = GetGitHub(result)
@@ -59,6 +59,32 @@ namespace OurUmbraco.Community.Map
             }
             
             return members;
+        }
+
+        /// <summary>
+        /// https://gizmodo.com/how-precise-is-one-degree-of-longitude-or-latitude-1631241162
+        /// </summary>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        private string GetLatitude(SearchResult result)
+        {
+            var lat = result.Fields["latitude"];
+            var latAsDouble = Double.Parse(lat);
+            var latRounded = Math.Round(latAsDouble, 4);
+            return latRounded.ToString();
+        }
+
+        /// <summary>
+        /// https://gizmodo.com/how-precise-is-one-degree-of-longitude-or-latitude-1631241162
+        /// </summary>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        private string GetLongitude(SearchResult result)
+        {
+            var lon = result.Fields["longitude"];
+            var lonAsDouble = Double.Parse(lon);
+            var lonRounded = Math.Round(lonAsDouble, 4);
+            return lonRounded.ToString();
         }
 
         private string GetGitHub(SearchResult result)

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -33,7 +33,7 @@ namespace OurUmbraco.Community.Map
                 .And().Field("blocked", "0")
                 .And().Field("umbracoMemberApproved", "1")                
                 .And().Range("latitudeNumber", longSwLat, longNeLat, true, true)
-                .And().Range("longitudeNumber", longSwLat, longNeLat, true, true)
+                .And().Range("longitudeNumber", longSwLon, longNeLon, true, true)
                 .Not().Range("karma", 0, 70, true, true);
 
 

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Web.Mvc;
 using Examine;
+using Examine.SearchCriteria;
 using Umbraco.Web.WebApi;
 using UmbracoExamine;
 
@@ -13,19 +14,16 @@ namespace OurUmbraco.Community.Map
         public List<MemberLocation> GetAllMemberLocations()
         { 
             var memberSearcher = ExamineManager.Instance.SearchProviderCollection["InternalMemberSearcher"];
-            var query = memberSearcher.CreateSearchCriteria(IndexTypes.Member);
-
+            var searchCritera = memberSearcher.CreateSearchCriteria(IndexTypes.Member);
+            
             //Find all active members - where a lat & lon is set (with new NodeGathering field to index)
-            query.Field("hasLocationSet", "1");
+            var query = searchCritera.Field("hasLocationSet", "1");
 
-                /*
-                .And().Field("blocked", "0")
-                .And().Field("umbracoMemberApproved ", "1").Compile();
-                */
+            //TODO: Check for members where blocked is false (0)
+            //And umbracoMemberApproved is true (1)
+            //I can't get to get it to work with the results I would expect currently
 
-            //Query
-            var results = memberSearcher.Search(query);
-            var rawQuery = query.ToString();
+            var results = memberSearcher.Search(query.Compile());
 
             //Pluck the fields we need from the Examine index fields
             //For our much simpler model to send back as the JSON response

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Mvc;
 using Examine;
-using Examine.SearchCriteria;
 using Umbraco.Web.WebApi;
 using UmbracoExamine;
 
@@ -19,9 +19,9 @@ namespace OurUmbraco.Community.Map
             //Find all active members - where a lat & lon is set (with new NodeGathering field to index)
             var query = searchCritera.Field("hasLocationSet", "1")
                 .And().Field("blocked", "0")
-                .And().Field("umbracoMemberApproved", "1");
-
-            var rawQuery = query.ToString();
+                .And().Field("umbracoMemberApproved", "1")
+                .Not().Range("karma", 0, 70, true, true); //Does not have karma points in between 0 to 70 (So must be over 70 then)
+            
             var results = memberSearcher.Search(query.Compile());
 
             //Pluck the fields we need from the Examine index fields
@@ -32,7 +32,8 @@ namespace OurUmbraco.Community.Map
                 Name = result.Fields["nodeName"],
                 Avatar = result.Fields["avatar"],
                 Lat = result.Fields["latitude"],
-                Lon = result.Fields["longitude"]
+                Lon = result.Fields["longitude"],
+                Karma = Convert.ToInt32(result.Fields["karma"])
             })
             .ToList();
             

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -15,25 +15,24 @@ namespace OurUmbraco.Community.Map
         { 
             var memberSearcher = ExamineManager.Instance.SearchProviderCollection["InternalMemberSearcher"];
             var searchCritera = memberSearcher.CreateSearchCriteria(IndexTypes.Member);
-            
+
             //Find all active members - where a lat & lon is set (with new NodeGathering field to index)
-            var query = searchCritera.Field("hasLocationSet", "1");
+            var query = searchCritera.Field("hasLocationSet", "1")
+                .And().Field("blocked", "0")
+                .And().Field("umbracoMemberApproved", "1");
 
-            //TODO: Check for members where blocked is false (0)
-            //And umbracoMemberApproved is true (1)
-            //I can't get to get it to work with the results I would expect currently
-
+            var rawQuery = query.ToString();
             var results = memberSearcher.Search(query.Compile());
 
             //Pluck the fields we need from the Examine index fields
             //For our much simpler model to send back as the JSON response
             var members = results.Select(result => new MemberLocation
             {
+                Id = result.Id,
                 Name = result.Fields["nodeName"],
-                Lat = result.Fields["latitude"],
-                Lon = result.Fields["longitude"],
                 Avatar = result.Fields["avatar"],
-                Id = result.Id
+                Lat = result.Fields["latitude"],
+                Lon = result.Fields["longitude"]
             })
             .ToList();
             

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Web.Mvc;
 using Examine;
 using Umbraco.Web.WebApi;
@@ -8,8 +9,8 @@ namespace OurUmbraco.Community.Map
 {
     public class MapApiController : UmbracoApiController
     {
-        [HttpGet ]
-        public ISearchResults GetAllMemberLocations()
+        [HttpGet]
+        public List<MemberLocation> GetAllMemberLocations()
         { 
             var memberSearcher = ExamineManager.Instance.SearchProviderCollection["InternalMemberSearcher"];
             var query = memberSearcher.CreateSearchCriteria(IndexTypes.Member);
@@ -24,9 +25,19 @@ namespace OurUmbraco.Community.Map
 
             //Query
             var results = memberSearcher.Search(query);
-
             var rawQuery = query.ToString();
-            return results;
+
+            //Pluck the fields we need from the Examine index fields
+            //For our much simpler model to send back as the JSON response
+            var members = results.Select(result => new MemberLocation
+            {
+                Name = result.Fields["nodeName"],
+                Lat = result.Fields["latitude"],
+                Lon = result.Fields["longitude"]
+            })
+            .ToList();
+            
+            return members;
         }
 
     }

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Web.Mvc;
 using Examine;
+using Examine.LuceneEngine.SearchCriteria;
 using Umbraco.Web.WebApi;
 using UmbracoExamine;
 
@@ -31,14 +32,15 @@ namespace OurUmbraco.Community.Map
             //Find all active members - where a lat & lon is set (with new NodeGathering field to index)
             var query = searchCritera.Field("hasLocationSet", "1")
                 .And().Field("blocked", "0")
-                .And().Field("umbracoMemberApproved", "1")                
+                .And().Field("umbracoMemberApproved", "1")
                 .And().Range("latitudeNumber", longSwLat, longNeLat, true, true)
                 .And().Range("longitudeNumber", longSwLon, longNeLon, true, true)
-                .Not().Range("karma", 0, 70, true, true);
+                .Not().Range("karma", 0, 70, true, true)
+                .And().OrderByDescending(new SortableField("karma", SortType.Int)); // Y U NO SORT
 
 
             var results = memberSearcher.Search(query.Compile());
-
+            
             //Pluck the fields we need from the Examine index fields
             //For our much simpler model to send back as the JSON response
             var members = results.Select(result => new MemberLocation

--- a/OurUmbraco/Community/Map/MapEventHandler.cs
+++ b/OurUmbraco/Community/Map/MapEventHandler.cs
@@ -1,0 +1,60 @@
+﻿using Examine;
+using Umbraco.Core;
+using UmbracoExamine;
+
+namespace OurUmbraco.Community.Map
+{
+    public class MapEventHandler : ApplicationEventHandler
+    {
+        private const string hasLocationIndexField = "hasLocationSet";
+
+        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            //Setup Gathering Node Data Examine Event for the Internal Member Index
+            //This is so that we can add 'null' to the lat & lon member fields
+            //Or add new computed field that is a bool - that indicates that the member has lat/lon info
+            //To help filter/exclude members who does not have this property set
+
+            ExamineManager.Instance.IndexProviderCollection["InternalMemberIndexer"].GatheringNodeData += MapEventHandler_GatheringNodeData;
+        }
+
+        private void MapEventHandler_GatheringNodeData(object sender, IndexingNodeDataEventArgs e)
+        {
+            //Even though the index is the internal members one
+            //Lets be certain that the indextype is member
+            if (e.IndexType != IndexTypes.Member)
+                return;
+
+            var hasLocationSet = false;
+
+            //Check if the fields
+            if (e.Fields.ContainsKey("longitude") && e.Fields.ContainsKey("latitude"))
+            {
+                //Next check its not null/empty value
+                if (string.IsNullOrEmpty(e.Fields["longitude"]) == false &&
+                    string.IsNullOrEmpty(e.Fields["latitude"]) == false)
+                {
+                    //We add this field into the index
+                    //We can then search for this field - to find all members who has lat & lon set
+                    hasLocationSet = true;
+                }
+
+            }
+
+            var valueToStore = hasLocationSet ? "1" : "0";  
+
+            //Check if the field exists already or not (to add or update)
+            if (e.Fields.ContainsKey(hasLocationIndexField))
+            {
+                //Update it
+                e.Fields[hasLocationIndexField] = valueToStore;
+            }
+            else
+            {
+                //Add/push it in
+                e.Fields.Add(hasLocationIndexField, valueToStore);
+            }
+
+        }
+    }
+}

--- a/OurUmbraco/Community/Map/MapEventHandler.cs
+++ b/OurUmbraco/Community/Map/MapEventHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Examine;
 using Lucene.Net.Documents;
 using System;
+using Examine.LuceneEngine.Providers;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using UmbracoExamine;
@@ -37,8 +38,8 @@ namespace OurUmbraco.Community.Map
             var existingField = e.Document.GetField("reputationCurrent");
             if (existingField != null)
             {
-                //Add new field that is numeric
-                var karmaField = new NumericField("karma", Field.Store.YES, true);
+                //Add new field that is numeric & prefix with the magic '__Sort_' string
+                var karmaField = new NumericField(LuceneIndexer.SortedFieldNamePrefix + "karma", Field.Store.YES, true);
 
                 //Get the existing value that is stored on the vanilla property that stores as strings
                 var existingValue = existingField.StringValue();

--- a/OurUmbraco/Community/Map/MapEventHandler.cs
+++ b/OurUmbraco/Community/Map/MapEventHandler.cs
@@ -26,9 +26,15 @@ namespace OurUmbraco.Community.Map
 
         private void Indexer_DocumentWriting(object sender, Examine.LuceneEngine.DocumentWritingEventArgs e)
         {
+            SetKarmaAsNumericField(e);
+            SetLocationAsDoubleField(e);
+        }
+
+        private static void SetKarmaAsNumericField(Examine.LuceneEngine.DocumentWritingEventArgs e)
+        {
             //Get existing field karma field - some members may not have a value set - so check in case
             var existingField = e.Document.GetField("reputationCurrent");
-            if(existingField != null)
+            if (existingField != null)
             {
                 //Add new field that is numeric
                 var karmaField = new NumericField("karma", Field.Store.YES, true);
@@ -45,7 +51,25 @@ namespace OurUmbraco.Community.Map
                 //Add the field to the document
                 e.Document.Add(karmaField);
             }
+        }
 
+        private static void SetLocationAsDoubleField(Examine.LuceneEngine.DocumentWritingEventArgs e)
+        {
+            //Get existing field - some members may not have a valueset - so check in case
+            var existingLatField = e.Document.GetField("latitude");
+            var existingLonField = e.Document.GetField("longitude");
+
+            if (existingLatField != null && existingLonField != null)
+            {
+                var latitude = Convert.ToDouble(existingLatField.StringValue());
+                var longitude = Convert.ToDouble(existingLonField.StringValue());
+
+                var latNumnber = new NumericField("latitudeNumber", Field.Store.YES, true).SetDoubleValue(latitude);
+                var lonNumnber = new NumericField("longitudeNumber", Field.Store.YES, true).SetDoubleValue(longitude);
+                
+                e.Document.Add(latNumnber);
+                e.Document.Add(lonNumnber);
+            }
         }
 
         private void MapEventHandler_GatheringNodeData(object sender, IndexingNodeDataEventArgs e)

--- a/OurUmbraco/Community/Map/MemberLocation.cs
+++ b/OurUmbraco/Community/Map/MemberLocation.cs
@@ -1,0 +1,11 @@
+﻿namespace OurUmbraco.Community.Map
+{
+    public class MemberLocation
+    {
+        public string Name { get; set; }
+
+        public string Lat { get; set; }
+
+        public string Lon { get; set; }
+    }
+}

--- a/OurUmbraco/Community/Map/MemberLocation.cs
+++ b/OurUmbraco/Community/Map/MemberLocation.cs
@@ -13,5 +13,11 @@
         public string Avatar { get; set; }
 
         public int Karma {  get; set; }
+
+        public string GitHub { get; set; }
+
+        public string Twitter { get; set; }
+
+        public bool SomeoneElseIsHere { get; set; }
     }
 }

--- a/OurUmbraco/Community/Map/MemberLocation.cs
+++ b/OurUmbraco/Community/Map/MemberLocation.cs
@@ -7,5 +7,9 @@
         public string Lat { get; set; }
 
         public string Lon { get; set; }
+
+        public int Id { get; set; }
+
+        public string Avatar { get; set; }
     }
 }

--- a/OurUmbraco/Community/Map/MemberLocation.cs
+++ b/OurUmbraco/Community/Map/MemberLocation.cs
@@ -11,5 +11,7 @@
         public int Id { get; set; }
 
         public string Avatar { get; set; }
+
+        public int Karma {  get; set; }
     }
 }

--- a/OurUmbraco/Our/Controllers/ProfileController.cs
+++ b/OurUmbraco/Our/Controllers/ProfileController.cs
@@ -11,15 +11,21 @@ namespace OurUmbraco.Our.Controllers
         {
             var ms = Services.MemberService;
             var mem = ms.GetById(Members.GetCurrentMemberId());
-            var m = new ProfileModel();
-            m.Name = mem.Name;
-            m.Email = mem.Email;
-            m.Bio = mem.GetValue<string>("profileText");
-            m.Location = mem.GetValue<string>("location");
-            m.Company = mem.GetValue<string>("company");
-            m.TwitterAlias = mem.GetValue<string>("twitter");
-            m.Avatar = mem.GetValue<string>("avatar");
-            m.GitHubUsername = mem.GetValue<string>("github");
+
+            var m = new ProfileModel
+            {
+                Name = mem.Name,
+                Email = mem.Email,
+                Bio = mem.GetValue<string>("profileText"),
+                Location = mem.GetValue<string>("location"),
+                Company = mem.GetValue<string>("company"),
+                TwitterAlias = mem.GetValue<string>("twitter"),
+                Avatar = mem.GetValue<string>("avatar"),
+                GitHubUsername = mem.GetValue<string>("github"),
+
+                Latitude = mem.GetValue<string>("latitude"), //TODO: Parse/cleanup bad data - auto remove it for user & resave the member?
+                Longitude = mem.GetValue<string>("longitude")
+            };
 
             return PartialView("~/Views/Partials/Members/Profile.cshtml", m);
         }
@@ -58,6 +64,11 @@ namespace OurUmbraco.Our.Controllers
             mem.SetValue("twitter",model.TwitterAlias);
             mem.SetValue("avatar", model.Avatar);
             mem.SetValue("github", model.GitHubUsername);
+
+            //Assume it's valid lat/lon data posted - as its a hidden field that a Google Map will update the lat & lon of hidden fields when marker moved
+            mem.SetValue("latitude", model.Latitude); 
+            mem.SetValue("longitude", model.Longitude);
+
             ms.Save(mem);
 
             var avatarImage = Utils.GetMemberAvatarImage(Members.GetById(mem.Id));
@@ -69,10 +80,9 @@ namespace OurUmbraco.Our.Controllers
 
             if(!string.IsNullOrEmpty(model.Password) && !string.IsNullOrEmpty(model.RepeatPassword) && model.Password == model.RepeatPassword)
                 ms.SavePassword(mem, model.Password);
-            ApplicationContext.ApplicationCache.RuntimeCache.ClearCacheItem("MemberData" + memberPreviousUserName);
-                
-            TempData["success"] = true;
 
+            ApplicationContext.ApplicationCache.RuntimeCache.ClearCacheItem("MemberData" + memberPreviousUserName);
+            TempData["success"] = true;
 
             return RedirectToCurrentUmbracoPage();
         }

--- a/OurUmbraco/Our/Models/ProfileModel.cs
+++ b/OurUmbraco/Our/Models/ProfileModel.cs
@@ -29,5 +29,9 @@ namespace OurUmbraco.Our.Models
 
         [Display(Name = "GitHub username")]
         public string GitHubUsername { get; set; }
+
+        public string Latitude { get; set; }
+
+        public string Longitude { get; set; }
     }
 }

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -421,6 +421,7 @@
     <Compile Include="Community\Karma\KarmaService.cs" />
     <Compile Include="Community\Map\MapApiController.cs" />
     <Compile Include="Community\Map\MapEventHandler.cs" />
+    <Compile Include="Community\Map\MemberLocation.cs" />
     <Compile Include="Community\Meetup\MeetupService.cs" />
     <Compile Include="Community\Meetup\Models\MeetupCacheItem.cs" />
     <Compile Include="Community\Models\MeetupEventsModel.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -419,6 +419,8 @@
     <Compile Include="Community\GitHub\Models\IGitHubContributorModel.cs" />
     <Compile Include="Community\GitHub\Models\GitHubContributorsResult.cs" />
     <Compile Include="Community\Karma\KarmaService.cs" />
+    <Compile Include="Community\Map\MapApiController.cs" />
+    <Compile Include="Community\Map\MapEventHandler.cs" />
     <Compile Include="Community\Meetup\MeetupService.cs" />
     <Compile Include="Community\Meetup\Models\MeetupCacheItem.cs" />
     <Compile Include="Community\Models\MeetupEventsModel.cs" />


### PR DESCRIPTION
Adds a PR to bring back the old member location Google Map - users have to opt in by giving their lat & lon on their member profile. So it's totally optional.

* Adds Examine OnGatheringNodeData event - to add new field to index - used to help filter/find members who have lat/lon info on their profile
* Adds an API Controller - to query Examine for members who have Lat & Lon fields set
* Simple partial view that uses CDF to require the JS it needs
* External JS file for loading our markers from API endpoint & the marker info window
* Adds Google's community library for clustering markers

**Note**
We need to test how well this performs with more/real world data than in the test DB.