### PR TITLE
Improvements to the community section sidebar

### DIFF
--- a/OurUmbraco.Site/Views/CommunityHubPageLayout.cshtml
+++ b/OurUmbraco.Site/Views/CommunityHubPageLayout.cshtml
@@ -33,37 +33,7 @@
 <div class="has-sidebar">
     <div class="page-content">
         <div id="overlay" class="overlay"></div>
-        <div class="sidebar-area">
-            <div class="sidebar-content">
-                <div class="content-wrapper">
-                    @if (allowed)
-                    {
-                        <nav>
-                            <ul class="level-1">
-                                @if (Model.Content.Level == 2)
-                                {
-                                    foreach (var child in Model.Content.Children)
-                                    {
-                                        <li class="">
-                                            <h3><a href="@child.Url">@child.Name</a></h3>
-                                        </li>
-                                    }
-                                }
-                                @if (Model.Content.Level == 3)
-                                {
-                                    foreach (var child in Model.Content.Parent.Children)
-                                    {
-                                        <li class="">
-                                            <h3><a href="@child.Url">@child.Name</a></h3>
-                                        </li>
-                                    }
-                                }
-                            </ul>
-                        </nav>
-                    }
-                </div><!-- .content-wrapper -->
-            </div><!-- .sidebar-content -->
-        </div><!-- .sidebar-area -->
+        @Html.Partial("~/Views/Partials/Community/Sidebar.cshtml")
         <div class="main-area">
             <div class="main-content">
                 <div class="content-wrapper">

--- a/OurUmbraco.Site/Views/Partials/Community/Sidebar.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Sidebar.cshtml
@@ -1,0 +1,49 @@
+﻿@using OurUmbraco.Our
+@using Skybrud.Essentials.Strings.Extensions
+@inherits UmbracoViewPage
+    
+@{
+
+    var featuresService = new UpcomingFeaturesService();
+    var allowed = featuresService.MemberHasAccessToFeature();
+
+}
+    
+<div class="sidebar-area">
+    <div class="sidebar-content">
+        <div class="content-wrapper">
+            @if (allowed)
+            {
+                <nav>
+                    <ul class="level-1">
+                        @foreach (var child in Model.AncestorOrSelf(2).Children)
+                        {
+
+                            var active = Model.Path.ToInt32Array().Contains(child.Id);
+                            var children = active ? child.Children.Where(x => x.IsVisible()).ToArray() : new IPublishedContent[0];
+
+                            <li class="@(active ? "active" : null)">
+                                <h3><a href="@child.Url">@child.Name</a>
+                                </h3>
+                                @if (children.Any())
+                                {
+                                    <ul>
+                                        @foreach (var child2 in children)
+                                        {
+
+                                            var active2 = Model.Path.ToInt32Array().Contains(child2.Id);
+
+                                            <li class="@(active2 ? "active" : null)">
+                                                <a href="@child2.Url"><h4>@child2.Name</h4></a>
+                                            </li>
+                                        }
+                                    </ul>
+                                }
+                            </li>
+                        }
+                    </ul>
+                </nav>
+            }
+        </div><!-- .content-wrapper -->
+    </div><!-- .sidebar-content -->
+</div><!-- .sidebar-area -->

--- a/OurUmbraco.Site/Views/Textpage.cshtml
+++ b/OurUmbraco.Site/Views/Textpage.cshtml
@@ -1,12 +1,41 @@
-﻿@inherits UmbracoTemplatePage
+﻿@using Skybrud.Essentials.Strings.Extensions
+@inherits UmbracoTemplatePage
 @{
     Layout = "~/Views/Master.cshtml";
+
+    var isCommunityTextPage = Model.Content.AncestorOrSelf(2).DocumentTypeAlias == "Community2";
+
 }
 
-<div id="body" class="page markdown-syntax">
-    <div>
-        @Html.Action("Render", "Breadcrumb", new { linkToCurrent = false })
+@if (isCommunityTextPage)
+{
+    <div class="has-sidebar">
+        <div class="page-content">
+            <div id="overlay" class="overlay"></div>
+            @Html.Partial("~/Views/Partials/Community/Sidebar.cshtml")
+            <div class="main-area">
+                <div class="main-content">
+                    <div class="content-wrapper">
+                        <div id="body" class="page markdown-syntax">
+                            <div>
+                                @Html.Action("Render", "Breadcrumb", new { linkToCurrent = true })
+                            </div>
+                            <h1>@Model.Content.Name</h1>
+                            @Html.Raw(Model.Content.GetPropertyValue<string>("bodyText"))
+                        </div><!-- #body -->
+                    </div><!-- .content-wrapper -->
+                </div><!-- .main-content -->
+            </div><!-- .main-area -->
+        </div><!-- .page-content -->
     </div>
-    <h1>@Model.Content.Name</h1>
-    @Html.Raw(Model.Content.GetPropertyValue<string>("bodyText"))
-</div>
+}
+else
+{
+    <div id="body" class="page markdown-syntax">
+        <div>
+            @Html.Action("Render", "Breadcrumb", new { linkToCurrent = false })
+        </div>
+        <h1>@Model.Content.Name</h1>
+        @Html.Raw(Model.Content.GetPropertyValue<string>("bodyText"))
+    </div>
+}


### PR DESCRIPTION
- [x] Sidebar shows active state at level 3 (see #170)
- [x] Sidebar shows children at level 4 (if there are any)
- [x] `Textpage` template is aware of the community section (enables sidebar if path matches)
- [x] Sidebar is handled by a partial view specific to the community section

![image](https://user-images.githubusercontent.com/3634580/37257541-31991672-256b-11e8-91c8-e4a2ceddd336.png)

I know the community section currently doesn't have any pages at the fourth level (at least not that I know of), but the sidebar will now support this.

My thought was that each community sub section could have some standard text pages (when it makes sense) describing that sub section - eg. **What is a meetup?** and **Can I add my own meetup?** for the **Meetups** sub section.

In my local solution - I've added a few pages of the type `Textpage`, but since the matching template didn't have a sidebar, I've updated the template to show this - but only when shown on a descendant of the Community section.

Should I add a pull request for the pages I've created so far? Or is it it best that the HQ does this? The text will live inside Umbraco in a RTE, so it will probably be a pain writing migrations for these if the text will later change.

So far my pages are:

> **What is a meetup?**
> Meetups are smaller events that are organized by the Umbraco community. A meetup typically takes place on a given day after business hours. It may be hosted by an agency in their offices, or simply in the local pub.

> **Can I add my own meetup?**
> Yes, sure. Our Umbraco is pulling new meetup events from Meetup based on a list of known user groups created and managed by the community. These groups are configured through the following configuration file:
> 
> https://github.com/umbraco/OurUmbraco/blob/master/OurUmbraco.Site/config/MeetupUmbracoGroups.txt
> 
> If you have your own user group (or just want to add one not already on the list), you can edit the file, which then let's you create a pull request.

> **What is a MVP?**
> Every year we honor the hardworking pillars of the Umbraco community - known as MVPs - or Most Valued People. We are humbled by the amount of work that is being put into the project be it on the forums, pull-requests, packages, festivals, meet-ups and whatever else this wonderful bunch of people get up to.