### PR TITLE
Fixes twitter on homepage if keys are invalid

### DIFF
--- a/OurUmbraco/Community/Twitter/TwitterService.cs
+++ b/OurUmbraco/Community/Twitter/TwitterService.cs
@@ -32,16 +32,18 @@ namespace OurUmbraco.Community.Twitter
                         () =>
                         {
                             Auth.SetUserCredentials(ConfigurationManager.AppSettings["twitterConsumerKey"],
-                                ConfigurationManager.AppSettings["twitterConsumerSecret"],
-                                ConfigurationManager.AppSettings["twitterUserAccessToken"],
-                                ConfigurationManager.AppSettings["twitterUserAccessSecret"]);
+                                    ConfigurationManager.AppSettings["twitterConsumerSecret"],
+                                    ConfigurationManager.AppSettings["twitterUserAccessToken"],
+                                    ConfigurationManager.AppSettings["twitterUserAccessSecret"]);
+
                             Tweetinvi.User.GetAuthenticatedUser();
 
                             var searchParameter = new SearchTweetsParameters("umbraco")
                             {
                                 SearchType = SearchResultType.Recent
                             };
-                            return Search.SearchTweets(searchParameter).ToArray();
+                            var results = Search.SearchTweets(searchParameter);
+                            return results == null ? new ITweet[]{} : results.ToArray();
 
                         }, TimeSpan.FromMinutes(2));
                 


### PR DESCRIPTION
Was expecting twitter to throw some kind of unauth ex, but we get a null. Now we return an empty array so the view doesn't blow up/throw a 500

Done as this was annoying me on local debug copy, when homepage fired up it would throw due to a null trying to be iterated on in the view