### PR TITLE
Be less of a creep!

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -22,11 +22,7 @@
 
 <script id="map-marker-template" type="x-tmpl-mustache">
     <div style="display:flex; align-items:center;">
-        <img src="{{Avatar}}" title="{{Name}}" style="margin-right:5px; border-radius:50%;" />
-        
-        <div>
-            <a href="/member/{{Id}}">{{Name}}</a>
-        </div>
+        <img src="{{Avatar}}" style="margin-right:5px; border-radius:50%;" />
     </div>
 </script>
 
@@ -41,12 +37,8 @@
 </script>
 
 <script id="member-item-template" type="x-tmpl-mustache">
-    <div style="border:1px solid grey; display:flex; padding:5px; flex-grow: 1; flex-shrink: 0; flex-basis: 40%; margin-right:5px; margin-bottom:5px; align-items:center;">
-        <img src="{{Avatar}}" title="{{Name}}" style="margin-right:5px; border-radius:50%;" />
-        
-        <div>
-            <a href="/member/{{Id}}">{{Name}}</a>
-        </div>
+    <div style="display:flex; padding:5px; flex-grow: 1; flex-shrink: 0; align-items:center;">
+        <img src="{{Avatar}}" style="border-radius:50%;" />
     </div>
 </script>
 

--- a/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Map.cshtml
@@ -26,22 +26,6 @@
         
         <div>
             <a href="/member/{{Id}}">{{Name}}</a>
-            <em>Karma: {{Karma}}</em>
-
-            <div class="social-links">
-                {{#Twitter}}
-                <a href="https://twitter.com/{{Twitter}}" title="See {{Name}}'s profile on Twitter" target="_blank" rel="noopener">
-                    <i class="icon-twitter" aria-hidden="true"></i>
-                    <span>{{Twitter}}</span>
-                </a>
-                {{/Twitter}}
-                {{#GitHub}}
-                <a href="https://github.com/{{Github}}" title="See {{Name}}'s profile on GitHub" target="_blank" rel="noopener">
-                    <i class="icon-github" aria-hidden="true"></i>
-                    <span>{{GitHub}}</span>
-                </a>
-                {{/GitHub}}
-            </div>
         </div>
     </div>
 </script>
@@ -62,22 +46,6 @@
         
         <div>
             <a href="/member/{{Id}}">{{Name}}</a>
-            <em>Karma: {{Karma}}</em>
-
-            <div class="social-links">
-                {{#Twitter}}
-                <a href="https://twitter.com/{{Twitter}}" title="See {{Name}}'s profile on Twitter" target="_blank" rel="noopener">
-                    <i class="icon-twitter" aria-hidden="true"></i>
-                    <span>{{Twitter}}</span>
-                </a>
-                {{/Twitter}}
-                {{#GitHub}}
-                <a href="https://github.com/{{Github}}" title="See {{Name}}'s profile on GitHub" target="_blank" rel="noopener">
-                    <i class="icon-github" aria-hidden="true"></i>
-                    <span>{{GitHub}}</span>
-                </a>
-                {{/GitHub}}
-            </div>
         </div>
     </div>
 </script>

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -43,10 +43,7 @@ namespace OurUmbraco.Community.Map
                 Name = result.Fields["nodeName"],
                 Avatar = GetAvatar(result),
                 Lat = GetLatitude(result),
-                Lon = GetLongitude(result),
-                Karma = Convert.ToInt32(result.Fields[LuceneIndexer.SortedFieldNamePrefix + "karma"]), //Have to access the value as the raw field name with the magic string prefix
-                Twitter = GetTwitter(result),
-                GitHub = GetGitHub(result)
+                Lon = GetLongitude(result)
             })
             .ToList();
 
@@ -85,18 +82,6 @@ namespace OurUmbraco.Community.Map
             var lonAsDouble = Double.Parse(lon);
             var lonRounded = Math.Round(lonAsDouble, 3);
             return lonRounded.ToString();
-        }
-
-        private string GetGitHub(SearchResult result)
-        {
-            //Verify if we have a record/field for it (not all members set this)
-            return result.Fields.ContainsKey("github") ? result.Fields["github"].Replace("@", "") : null;
-        }
-
-        private string GetTwitter(SearchResult result)
-        {
-            //Verify if we have a record/field for it (not all members set this)
-            return result.Fields.ContainsKey("twitter") ? result.Fields["twitter"].Replace("@", "") : null;
         }
 
         private string GetAvatar(SearchResult result)

--- a/OurUmbraco/Community/Map/MapApiController.cs
+++ b/OurUmbraco/Community/Map/MapApiController.cs
@@ -38,23 +38,13 @@ namespace OurUmbraco.Community.Map
             //Pluck the fields we need from the Examine index fields
             //For our much simpler model to send back as the JSON response
             var members = results.Select(result => new MemberLocation
-            {
-                Id = result.Id,
-                Name = result.Fields["nodeName"],
+            {   
                 Avatar = GetAvatar(result),
                 Lat = GetLatitude(result),
                 Lon = GetLongitude(result)
             })
             .ToList();
 
-            //Loop over list and try to find members that have the exact same lat & lon
-            //Mark them as a 'someoneElseIsHere' to true
-            foreach (var member in members)
-            {
-                //Check if a member exist with same lat & lon & exclude itself from the lookup
-                member.SomeoneElseIsHere = members.Exists(x => x.Lat == member.Lat && x.Lon == member.Lon && x.Id != member.Id);
-            }
-            
             return members;
         }
 

--- a/OurUmbraco/Community/Map/MemberLocation.cs
+++ b/OurUmbraco/Community/Map/MemberLocation.cs
@@ -12,12 +12,6 @@
 
         public string Avatar { get; set; }
 
-        public int Karma {  get; set; }
-
-        public string GitHub { get; set; }
-
-        public string Twitter { get; set; }
-
         public bool SomeoneElseIsHere { get; set; }
     }
 }

--- a/OurUmbraco/Community/Map/MemberLocation.cs
+++ b/OurUmbraco/Community/Map/MemberLocation.cs
@@ -2,16 +2,10 @@
 {
     public class MemberLocation
     {
-        public string Name { get; set; }
-
         public string Lat { get; set; }
 
         public string Lon { get; set; }
-
-        public int Id { get; set; }
-
+        
         public string Avatar { get; set; }
-
-        public bool SomeoneElseIsHere { get; set; }
     }
 }


### PR DESCRIPTION
Removes GitHub, Twitter & Karma count from the marker Pins & API response. We still sort members by karma though for many users at location when zoom level is close.