### PR TITLE
Fix Gitter Bootup issue - if room no longer exists

### DIFF
--- a/OurUmbraco/Gitter/GitterUmbracoEventHandler.cs
+++ b/OurUmbraco/Gitter/GitterUmbracoEventHandler.cs
@@ -82,10 +82,20 @@ namespace OurUmbraco.Gitter
                     applicationContext.ApplicationCache.StaticCache.GetCacheItem<Room>("GitterRoom__" + roomName,
                         () =>
                         {
-                            return gitterService.GetRoomInfo(roomName).Result;
-
+                            try
+                            {
+                                return gitterService.GetRoomInfo(roomName).Result;
+                            }
+                            catch (Exception ex)
+                            {
+                                //Log & swallow - don't cause app not to boot up
+                                applicationContext.ProfilingLogger.Logger.Error<GitterUmbracoEventHandler>($"Cannot Get Gitter Room Info for {roomName}", ex);
+                                return null;
+                            }
                         });
 
+                if(room == null)
+                    continue;
 
                 //User presence
                 realtimeGitterService.SubscribeToUserPresence(room.Id)


### PR DESCRIPTION
Better error handling for trying to connect to rooms that do not exist