### PR TITLE
#200 - Gitter Mentions

### DIFF
--- a/OurUmbraco.Site/Assets/js/gitter/gitter.signalr.js
+++ b/OurUmbraco.Site/Assets/js/gitter/gitter.signalr.js
@@ -100,4 +100,48 @@
         var emjoiHtml = emojione.toImage(html);
         return emjoiHtml;
     }
+
+
+    function tryUpdateMentions() {
+        //Notifies us for all DOM changes made to the body
+        var somethingHasChanged = function (mutations) {
+
+            for (var j = 0; j < mutations.length; j++) {
+                var mutation = mutations[j];
+
+                if (mutation.addedNodes) {
+                    var jq = $(mutation.addedNodes);
+
+                    jq.find("span[data-link-type='mention']").each(function () {
+                        var element = $(this);
+                        var username = element.data('screen-name');
+
+                        var memberId = null;
+                        $.getJSON("/umbraco/api/gitterapi/GetMemberId?usernameToFind=" + username, function (data) {
+                            memberId = data;
+
+                            if (memberId) {
+                                element.html("<a href='/member/" + memberId + "'>@" + username + "</a>");
+                            }
+                        });
+                    });
+                }
+            }
+        };
+
+        var observer = new MutationObserver(somethingHasChanged);
+        var config = {
+            attributes: true,
+            childList: true,
+            characterData: true
+        };
+
+        var gitterRooms = document.getElementsByClassName('gitter-room');
+        for (var i = 0; i < gitterRooms.length; i++) {
+            observer.observe(gitterRooms[i], config);
+        }
+    }
+
+    tryUpdateMentions();
+
 });

--- a/OurUmbraco/Gitter/GitterApiController.cs
+++ b/OurUmbraco/Gitter/GitterApiController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using OurUmbraco.Community.People;
+using Umbraco.Web.WebApi;
+
+namespace OurUmbraco.Gitter
+{
+    
+    public class GitterApiController : UmbracoApiController
+    {
+        /// <summary>
+        /// Called from JS - in attempt to update the username mentions in chat messages
+        /// </summary>
+        /// <param name="usernameToFind"></param>
+        /// <returns></returns>
+        [HttpGet]
+        public int? GetMemberId(string usernameToFind)
+        {
+            var peopleService = new PeopleService();
+            return peopleService.GetMemberIdFromGithubName(usernameToFind);
+        }
+    }
+}

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -503,6 +503,7 @@
     <Compile Include="Forum\Services\ForumService.cs" />
     <Compile Include="Forum\Services\TopicService.cs" />
     <Compile Include="Forum\Singleton.cs" />
+    <Compile Include="Gitter\GitterApiController.cs" />
     <Compile Include="Gitter\GitterProxyHub.cs" />
     <Compile Include="Gitter\GitterRoomSurfaceController.cs" />
     <Compile Include="Gitter\GitterService.cs" />


### PR DESCRIPTION
Fixes Issue #200 

Adds API controller to look up gitter username (which we assume is same as github username)
JS monitors DOM & if new chat message added that contains span with data attribute we make an API call to check to see if we can find that user/member.

If so then we update the HTML with a link to that members profile