### PR TITLE
Blogs: Should only include Umbraco related posts

### DIFF
--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -185,7 +185,7 @@
       "checkTitles": false,
       "title": "Anders Bjerner",
       "url": "http://www.bjerner.dk/blog/",
-      "rss": "http://www.bjerner.dk/blog/rss/",
+      "rss": "http://www.bjerner.dk/blog/tags/umbraco/rss",
       "logo": "http://www.gravatar.com/avatar/e3ad43cc015da910c21237961fa6d74d.jpg?s=256&d=mm",
       "memberId": 66039
     },


### PR DESCRIPTION
Rewrote my blog and RSS feed so that it know supports filtering by tags 😃 