### PR TITLE
WebForms? Yikes!

### DIFF
--- a/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
+++ b/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
@@ -73,7 +73,7 @@
                         <li class="@result.SolvedClass()">
                             <a href="@result.FullUrl()">
                                 <div class="type-icon">
-                                    <i class="<%=result.GetIcon() %>"></i>
+                                    <i class="@result.GetIcon()"></i>
                                 </div>
 
                                 <div class="type-context">


### PR DESCRIPTION
The icon to the left in each result result item isn't rendered properly since the statement outputting the class name hasn't been converted from the old WebForms.

With this commit, I've changed the line so it uses the proper Razor syntax, and the results then look like as shown below:

![image](https://user-images.githubusercontent.com/3634580/39592801-27d0d8f2-4f08-11e8-9bff-b1e653d9d0be.png)
