### PR TITLE
Searchable blog posts

### DIFF
--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -4394,6 +4394,7 @@
     <Content Include="Views\Partials\Grid\Bootstrap3-Fluid.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap2.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap2-Fluid.cshtml" />
+    <Content Include="Views\Partials\Search\BlogItem.cshtml" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/OurUmbraco.Site/Views/Partials/Community/Blogs.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Blogs.cshtml
@@ -4,9 +4,13 @@
 
 @inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 @{
-    var service = new BlogPostsService();
 
-    var items = service.GetCachedBlogPosts(60, 4).ToArray();
+    var cache = new BlogPostsCache();
+    
+    var blogs = cache.GetBlogs();
+    ViewBag.Blogs = blogs;
+    
+    var items = cache.GetCachedBlogPosts(60, 4).ToArray();
 
     if (items.Length == 0)
     {

--- a/OurUmbraco.Site/Views/Partials/Search/BlogItem.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Search/BlogItem.cshtml
@@ -1,0 +1,30 @@
+﻿@using OurUmbraco.Community.BlogPosts
+@inherits UmbracoViewPage<OurUmbraco.Search.BlogItemSearchResult>
+    
+@{
+
+    if (Model.Blog == null)
+    {
+        return;
+    }
+
+}
+
+<li>
+    <a href="@Model.Item.Link" target="_blank" rel="noopener">
+        <div class="type-icon">
+            <i class="icon-Rss"></i>
+        </div>
+        <div class="type-context">
+            <div class="type-name">
+                @Model.Item.Title
+                <span style="color: #445255; font-size: 14px;">(via @Model.Blog.Title)</span>
+            </div>
+            <span class="type-datetime">Published: @Model.Item.PublishedDate.ToString("MMMM dd, yyyy")</span>
+            @if (Model.Item.HasDescription)
+            {
+                <div class="type-description">@Umbraco.Truncate(Model.Item.Description, 300)</div>
+            }
+        </div>
+    </a>
+</li>

--- a/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
+++ b/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
@@ -1,5 +1,14 @@
-﻿@using OurUmbraco.Our
+﻿@using OurUmbraco.Community.BlogPosts
+@using OurUmbraco.Our
+@using OurUmbraco.Search
+@using Skybrud.Essentials.Json
 @model OurUmbraco.Our.Models.SearchResultContentModel
+
+@{
+
+    BlogPostsService blogs = null;
+
+}
 
 <div class="plain">
     <!-- search OVERVIEW START -->
@@ -69,7 +78,38 @@
                 }
 
                 <ul class="search-all-results docs-search-listing">
-                    @foreach(var result in Model.Results.SearchResults) { 
+                    @foreach(var result in Model.Results.SearchResults) {
+
+                        string nodeTypeAlias = result["nodeTypeAlias"];
+                        
+                        if (nodeTypeAlias == "blogItem")
+                        {
+
+                            string rawData;
+                            if (result.Fields.TryGetValue("data", out rawData))
+                            {
+
+                                // Get the ID of the blog
+                                string blogId = result["blogId"];
+
+                                // Only initialize the service if we need it
+                                blogs = blogs ?? new BlogPostsService();
+
+                                // Find the blog
+                                BlogInfo blog = blogs.GetBlogs().FirstOrDefault(x => x.Id.ToString() == blogId);
+
+                                // Parse the JSON from the search result
+                                BlogRssItem rss = JsonUtils.ParseJsonObject<BlogRssItem>(rawData);
+
+                                @Html.Partial("~/Views/Partials/Search/BlogItem.cshtml", new BlogItemSearchResult(result, rss, blog))
+
+                                continue;
+
+                            }
+
+                        }
+
+
                         <li class="@result.SolvedClass()">
                             <a href="@result.FullUrl()">
                                 <div class="type-icon">

--- a/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
+++ b/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
@@ -88,23 +88,9 @@
                             string rawData;
                             if (result.Fields.TryGetValue("data", out rawData))
                             {
-
-                                // Get the ID of the blog
-                                string blogId = result["blogId"];
-
-                                // Only initialize the service if we need it
-                                blogs = blogs ?? new BlogPostsService();
-
-                                // Find the blog
-                                BlogInfo blog = blogs.GetBlogs().FirstOrDefault(x => x.Id.ToString() == blogId);
-
-                                // Parse the JSON from the search result
-                                BlogRssItem rss = JsonUtils.ParseJsonObject<BlogRssItem>(rawData);
-
-                                @Html.Partial("~/Views/Partials/Search/BlogItem.cshtml", new BlogItemSearchResult(result, rss, blog))
-
+                                BlogInfo blog = (blogs = (blogs ?? new BlogPostsService())).GetBlogs().FirstOrDefault(x => x.Id.ToString() == result["blogId"]);
+                                @Html.Partial("~/Views/Partials/Search/BlogItem.cshtml", new BlogItemSearchResult(result, blog))
                                 continue;
-
                             }
 
                         }

--- a/OurUmbraco.Site/config/ExamineIndex.config
+++ b/OurUmbraco.Site/config/ExamineIndex.config
@@ -111,5 +111,21 @@ More information and documentation can be found on CodePlex: http://umbracoexami
             <add Name="memberId" />
         </IndexUserFields>
     </IndexSet>
+  
+  <!-- Documentation (Custom) -->
+  <IndexSet SetName="BlogItemsIndexSet" IndexPath="~/App_Data/TEMP/ExamineIndexes/BlogItems/">
+    <IndexUserFields>
+      <add Name="body"/>
+      <add Name="nodeName"/>
+      <add Name="createDate" EnableSorting="true" Type="DateTime"/>
+      <add Name="updateDate" EnableSorting="true" Type="DateTime"/>
+      <add Name="description"/>
+      <add Name="blogId"/>
+      <add Name="url"/>
+      <add Name="nodeTypeAlias" />
+      <add Name="data"/>
+    </IndexUserFields>
+
+  </IndexSet>
 
 </ExamineLuceneIndexSets>

--- a/OurUmbraco.Site/config/ExamineSettings.config
+++ b/OurUmbraco.Site/config/ExamineSettings.config
@@ -47,6 +47,13 @@ More information and documentation can be found on CodePlex: http://umbracoexami
               analyzer="Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"
               indexTypes="PullRequest"/>
 
+          <add name="BlogItemsIndexer" type="Examine.LuceneEngine.Providers.SimpleDataIndexer, Examine"
+               autoOptimize="false"
+               indexSet="BlogItemsIndexSet"
+               dataService="OurUmbraco.Our.Examine.BlogItemsIndexDataService, OurUmbraco"
+               analyzer="Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net"
+               indexTypes="blogItems"/>
+
         </providers>
 
     </ExamineIndexProviders>
@@ -71,10 +78,14 @@ More information and documentation can be found on CodePlex: http://umbracoexami
 
             <add name="MultiIndexSearcher"
                type="Examine.LuceneEngine.Providers.MultiIndexSearcher, Examine"
-               indexSets="ForumIndexSet,projectIndexSet,documentationIndexSet"
+               indexSets="ForumIndexSet,projectIndexSet,documentationIndexSet,BlogItemsIndexSet"
                enableLeadingWildcards="true" />
 
             <add name="PullRequestSearcher" type="Examine.LuceneEngine.Providers.LuceneSearcher, Examine" />
+
+          <add name="BlogItemsSearcher"
+               type="Examine.LuceneEngine.Providers.LuceneSearcher, Examine"
+               indexSet="BlogItemsIndexSet" analyzer="Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net" />
 
         </providers>
     </ExamineSearchProviders>

--- a/OurUmbraco/Community/BlogPosts/BlogDatabaseItem.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogDatabaseItem.cs
@@ -8,7 +8,7 @@ namespace OurUmbraco.Community.BlogPosts
 {
 
     [TableName(TableName)]
-    [PrimaryKey(PrimaryKey, autoIncrement = false)]
+    [PrimaryKey(PrimaryKey, autoIncrement = true)]
     [ExplicitColumns]
     public class BlogDatabaseItem
     {
@@ -20,8 +20,11 @@ namespace OurUmbraco.Community.BlogPosts
         private BlogRssItem _data;
 
         [Column(PrimaryKey)]
-        [PrimaryKeyColumn(AutoIncrement = false)]
-        public string Id { get; set; }
+        [PrimaryKeyColumn(AutoIncrement = true)]
+        public int Id { get; set; }
+
+        [Column("UniqueId")]
+        public string UniqueId { get; set; }
 
         [Column("BlogId")]
         public string BlogId { get; set; }

--- a/OurUmbraco/Community/BlogPosts/BlogDatabaseItem.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogDatabaseItem.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Newtonsoft.Json;
+using Skybrud.Essentials.Json;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+
+namespace OurUmbraco.Community.BlogPosts
+{
+
+    [TableName(TableName)]
+    [PrimaryKey(PrimaryKey, autoIncrement = false)]
+    [ExplicitColumns]
+    public class BlogDatabaseItem
+    {
+
+        public const string TableName = "CommunityBlogItems";
+
+        public const string PrimaryKey = "Id";
+
+        private BlogRssItem _data;
+
+        [Column(PrimaryKey)]
+        [PrimaryKeyColumn(AutoIncrement = false)]
+        public string Id { get; set; }
+
+        [Column("BlogId")]
+        public string BlogId { get; set; }
+
+        [Column("PubDate")]
+        public DateTime PublishedDate { get; set; }
+
+        [Column("Title")]
+        public string Title { get; set; }
+
+        [Column("Data")]
+        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        public string DataRaw { get; set; }
+
+        [Ignore]
+        public BlogRssItem Data
+        {
+            get { return _data ?? JsonUtils.ParseJsonObject<BlogRssItem>(DataRaw); }
+            set { _data = value; DataRaw = JsonConvert.SerializeObject(_data, Formatting.None); }
+        }
+
+    }
+
+}

--- a/OurUmbraco/Community/BlogPosts/BlogInfo.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogInfo.cs
@@ -10,7 +10,7 @@ namespace OurUmbraco.Community.BlogPosts {
     /// </summary>
     public class BlogInfo {
 
-        public string Id { get; private set; }
+        public Guid Id { get; private set; }
 
         public string Title { get; private set; }
 
@@ -35,7 +35,7 @@ namespace OurUmbraco.Community.BlogPosts {
         public Encoding Encoding { get; set; }
 
         private BlogInfo(JObject obj) {
-            Id = obj.GetString("id");
+            Id = obj.GetString("id", Guid.Parse);
             Title = obj.GetString("title");
             Url = obj.GetString("url");
             RssUrl = obj.GetString("rss");

--- a/OurUmbraco/Community/BlogPosts/BlogPostsCache.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsCache.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Skybrud.Essentials.Json;
+using Skybrud.Essentials.Json.Extensions;
+using Umbraco.Core.IO;
+using Umbraco.Core.Logging;
+
+namespace OurUmbraco.Community.BlogPosts
+{
+
+    public class BlogPostsCache
+    {
+
+        public static readonly string BlogsJsonFile = IOHelper.MapPath("~/config/CommunityBlogs.json");
+
+        public static readonly string PostsJsonFile = IOHelper.MapPath("~/App_Data/TEMP/CommunityBlogPosts.json");
+
+        /// <summary>
+        /// Gets an array with information about the blogs stored in the <c>~/config/CommunityBlogs.json</c> configuration file.
+        /// </summary>
+        /// <returns>Array of <see cref="BlogInfo"/>.</returns>
+        public BlogInfo[] GetBlogs()
+        {
+
+            // Check whether the config file exists
+            var configPath = BlogsJsonFile;
+            if (File.Exists(BlogsJsonFile) == false)
+            {
+                LogHelper.Warn<BlogPostsService>("Config file was not found: " + configPath);
+                return new BlogInfo[0];
+            }
+
+            // Attempt to load information about each blog
+            try
+            {
+                var root = JsonUtils.LoadJsonObject(configPath);
+                return root.GetArrayItems("blogs", BlogInfo.Parse);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<BlogPostsService>("Unable to parse config file", ex);
+                return new BlogInfo[0];
+            }
+        }
+        public BlogCachedRssItem[] GetCachedBlogPosts(int take, int numberOfPostsPerBlog)
+        {
+            
+            // Return an empty array as the file doesn't exist
+            if (File.Exists(PostsJsonFile) == false) return new BlogCachedRssItem[0];
+
+            var blogs = GetBlogs().ToDictionary(x => x.Id.ToString());
+
+            try
+            {
+                var blogPosts = new List<BlogCachedRssItem>();
+
+                foreach (var item in JsonUtils.LoadJsonArray(PostsJsonFile).Select(token => token.ToObject<BlogRssItem>()))
+                {
+                    if (blogs.TryGetValue(item.Channel.Id, out var blog) == false)
+                        continue;
+
+                    blog.LogoUrl = $"/media/blogs/{blog.Id}{BlogUtils.GetFileExtension(blog.LogoUrl)}";
+                    blogPosts.Add(new BlogCachedRssItem(blog, item));
+                }
+
+                var filteredBlogPosts = new List<BlogCachedRssItem>();
+                foreach (var item in blogPosts)
+                    if (filteredBlogPosts.Count(b => b.Blog.Id == item.Blog.Id) < numberOfPostsPerBlog)
+                        filteredBlogPosts.Add(item);
+
+                return filteredBlogPosts.Take(take).OrderByDescending(x => x.PublishedDate).ToArray();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<BlogPostsService>("Unable to load blog posts from JSON file", ex);
+                return new BlogCachedRssItem[0];
+            }
+
+        }
+
+    }
+
+}

--- a/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
@@ -77,7 +77,7 @@ namespace OurUmbraco.Community.BlogPosts
 
                         // Download the raw XML
                         raw = wc.DownloadString(blog.RssUrl);
-                        raw = BlogRssUtils.RemoveLeadingCharacters(raw).Replace("a10:updated", "pubDate");
+                        raw = BlogUtils.RemoveLeadingCharacters(raw).Replace("a10:updated", "pubDate");
                     }
                     // Parse the XML into a new instance of XElement
                     var feed = XElement.Parse(raw);
@@ -105,7 +105,7 @@ namespace OurUmbraco.Community.BlogPosts
                             : item.GetElementValue("link"))
                                 .Trim();
 
-                        var pubDate = BlogRssUtils.GetPublishDate(item);
+                        var pubDate = BlogUtils.GetPublishDate(item);
                         if (pubDate == default(DateTimeOffset))
                             continue;
 
@@ -168,7 +168,7 @@ namespace OurUmbraco.Community.BlogPosts
                         if (Directory.Exists(baseLogoPath) == false)
                             Directory.CreateDirectory(baseLogoPath);
                         
-                        var logoExtension = BlogRssUtils.GetFileExtension(blog.LogoUrl);
+                        var logoExtension = BlogUtils.GetFileExtension(blog.LogoUrl);
                         var logoPath = baseLogoPath + blog.Id + logoExtension;
                         
                         wc.DownloadFile(blog.LogoUrl, logoPath);
@@ -202,7 +202,7 @@ namespace OurUmbraco.Community.BlogPosts
                     if (blogs.TryGetValue(item.Channel.Id, out var blog) == false)
                         continue;
 
-                    blog.LogoUrl = $"/media/blogs/{blog.Id}{BlogRssUtils.GetFileExtension(blog.LogoUrl)}";
+                    blog.LogoUrl = $"/media/blogs/{blog.Id}{BlogUtils.GetFileExtension(blog.LogoUrl)}";
                     blogPosts.Add(new BlogCachedRssItem(blog, item));
                 }
 

--- a/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
@@ -127,7 +127,7 @@ namespace OurUmbraco.Community.BlogPosts
 
         }
 
-        public BlogDatabaseItem[] GetAllBlogItemsFromDatabase()
+        public BlogDatabaseItem[] GetBlogPosts()
         {
 
             // Get a list of all existing blog items and add them to a dictionary

--- a/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
@@ -82,7 +82,7 @@ namespace OurUmbraco.Community.BlogPosts
 
                     var rssChannel = new BlogRssChannel
                     {
-                        Id = blog.Id,
+                        Id = blog.Id.ToString(),
                         Title = channelTitle,
                         Link = channelLink
                     };
@@ -232,7 +232,7 @@ namespace OurUmbraco.Community.BlogPosts
             if (File.Exists(JsonFile) == false)
                 return new BlogCachedRssItem[0];
 
-            var blogs = GetBlogs().ToDictionary(x => x.Id);
+            var blogs = GetBlogs().ToDictionary(x => x.Id.ToString());
 
             try
             {

--- a/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
@@ -14,6 +14,7 @@ using Skybrud.Essentials.Json.Extensions;
 using Skybrud.Essentials.Xml.Extensions;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence;
 
 namespace OurUmbraco.Community.BlogPosts
 {
@@ -21,6 +22,14 @@ namespace OurUmbraco.Community.BlogPosts
     public class BlogPostsService
     {
         private static readonly string JsonFile = HostingEnvironment.MapPath("~/App_Data/TEMP/CommunityBlogPosts.json");
+
+        protected UmbracoDatabase Database { get; private set; }
+
+        public BlogPostsService()
+        {
+            Database = ApplicationContext.Current.DatabaseContext.Database;
+        }
+
 
         public BlogInfo[] GetBlogs()
         {
@@ -259,6 +268,16 @@ namespace OurUmbraco.Community.BlogPosts
                 LogHelper.Error<BlogPostsService>("Unable to load blog posts from JSON file", ex);
                 return new BlogCachedRssItem[0];
             }
+        }
+        
+        public BlogDatabaseItem[] GetAllBlogItemsFromDatabase()
+        {
+
+            // Get a list of all existing blog items and add them to a dictionary
+            Sql sqæl = new Sql().Select("*").From(BlogDatabaseItem.TableName);
+
+            return Database.Fetch<BlogDatabaseItem>(sqæl).ToArray();
+
         }
 
         public void UpdateBlogPostsJsonFile()

--- a/OurUmbraco/Community/BlogPosts/BlogPostsWebClient.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsWebClient.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Web.Hosting;
+using System.Xml.Linq;
+using Hangfire.Console;
+using Hangfire.Server;
+using Skybrud.Essentials.Xml.Extensions;
+using Umbraco.Core;
+
+namespace OurUmbraco.Community.BlogPosts
+{
+
+    public class BlogPostsWebClient
+    {
+
+        /// <summary>
+        /// Gets an array of the most recent RSS items of <paramref name="blogs"/> from the interwebz.
+        /// </summary>
+        /// <param name="blogs">Array of blogs.</param>
+        /// <param name="context"></param>
+        /// <returns>Array of <see cref="BlogRssItem"/>.</returns>
+        public BlogRssItem[] GetBlogPosts(BlogInfo[] blogs, PerformContext context)
+        {
+            var posts = new List<BlogRssItem>();
+
+            var progressBar = context.WriteProgressBar();
+
+            foreach (var blog in blogs.WithProgress(progressBar, blogs.Length))
+            {
+                try
+                {
+                    string raw;
+                    const string userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3393.4 Safari/537.36";
+                    context.WriteLine($"Processing blog {blog.Title}");
+                    // Initialize a new web client (with the encoding specified for the blog)
+                    using (var wc = new WebClient())
+                    {
+                        wc.Headers.Add(HttpRequestHeader.UserAgent, userAgent);
+                        wc.Encoding = blog.Encoding;
+
+                        // Download the raw XML
+                        raw = wc.DownloadString(blog.RssUrl);
+                        raw = BlogUtils.RemoveLeadingCharacters(raw).Replace("a10:updated", "pubDate");
+                    }
+                    // Parse the XML into a new instance of XElement
+                    var feed = XElement.Parse(raw);
+
+                    var channel = feed.Element("channel");
+                    var channelTitle = channel.GetElementValue("title");
+                    var channelLink = channel.GetElementValue("link");
+                    var channelDescription = channel.GetElementValue("description");
+                    var channelLastBuildDate = channel.GetElementValue("lastBuildDate");
+                    var channelLangauge = channel.GetElementValue("language");
+
+                    var rssChannel = new BlogRssChannel
+                    {
+                        Id = blog.Id.ToString(),
+                        Title = channelTitle,
+                        Link = channelLink
+                    };
+
+                    var items = channel.GetElements("item");
+                    foreach (var item in items)
+                    {
+                        var title = item.GetElementValue("title");
+                        var link = (string.IsNullOrEmpty(item.GetElementValue("link"))
+                                ? item.GetElementValue("guid")
+                                : item.GetElementValue("link"))
+                            .Trim();
+
+                        var pubDate = BlogUtils.GetPublishDate(item);
+                        if (pubDate == default(DateTimeOffset))
+                            continue;
+
+                        var approvedCategories = new List<string> { "umbraco", "codegarden", "articulate", "examine" };
+                        var categories = item.GetElements("category");
+                        if (categories.Any())
+                        {
+                            var includeItem = title.ToLowerInvariant().ContainsAny(approvedCategories);
+                            foreach (var category in categories)
+                            {
+                                // no need to check more if the item is already approved
+                                if (includeItem)
+                                    continue;
+
+                                foreach (var approvedCategory in approvedCategories)
+                                    if (category.Value.ToLowerInvariant().Contains(approvedCategory.ToLowerInvariant()))
+                                        includeItem = true;
+                            }
+
+                            if (includeItem == false)
+                            {
+                                var allCategories = string.Join(",", categories.Select(i => i.Value));
+                                context.SetTextColor(ConsoleTextColor.DarkYellow);
+                                context.WriteLine($"Not including post titled {title} because it was not in an approved category. The categories it was found in: {allCategories}. [{link}]");
+                                context.ResetTextColor();
+                                continue;
+                            }
+                        }
+
+                        // Blog has no category info and posts things unrelated to Umbraco, check there's related keywords in the title
+                        if (blog.CheckTitles)
+                        {
+                            var includeItem = false;
+                            foreach (var approvedCategory in approvedCategories)
+                                if (title.ToLowerInvariant().Contains(approvedCategory.ToLowerInvariant()))
+                                    includeItem = true;
+
+                            // Blog post seems unrelated to Umbraco, skip it
+                            if (includeItem == false)
+                                continue;
+                        }
+
+                        var blogPost = new BlogRssItem
+                        {
+                            Channel = rssChannel,
+                            Title = title,
+                            // some sites store the link in the <guid/> element 
+                            Link = link,
+                            PublishedDate = pubDate
+                        };
+
+                        posts.Add(blogPost);
+                    }
+
+                    // Get the avatar locally so that we can use ImageProcessor and serve it over https
+                    using (var wc = new WebClient())
+                    {
+                        wc.Headers.Add(HttpRequestHeader.UserAgent, userAgent);
+                        var baseLogoPath = HostingEnvironment.MapPath("~/media/blogs/");
+                        if (Directory.Exists(baseLogoPath) == false)
+                            Directory.CreateDirectory(baseLogoPath);
+
+                        var logoExtension = BlogUtils.GetFileExtension(blog.LogoUrl);
+                        var logoPath = baseLogoPath + blog.Id + logoExtension;
+
+                        wc.DownloadFile(blog.LogoUrl, logoPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    context.SetTextColor(ConsoleTextColor.Red);
+                    context.WriteLine("Unable to get blog posts for: " + blog.RssUrl, ex);
+                    context.ResetTextColor();
+                }
+            }
+
+            return posts.OrderByDescending(x => x.PublishedDate).ToArray();
+        }
+
+    }
+
+}

--- a/OurUmbraco/Community/BlogPosts/BlogPostsWebClient.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsWebClient.cs
@@ -80,6 +80,9 @@ namespace OurUmbraco.Community.BlogPosts
                         if (pubDate == default(DateTimeOffset))
                             continue;
 
+                        string description = item.GetElementValue("description");
+                        if (String.IsNullOrWhiteSpace(description)) description = null;
+
                         var approvedCategories = new List<string> { "umbraco", "codegarden", "articulate", "examine" };
                         var categories = item.GetElements("category");
                         if (categories.Any())
@@ -126,7 +129,8 @@ namespace OurUmbraco.Community.BlogPosts
                             // some sites store the link in the <guid/> element
                             Guid = guid,
                             Link = link,
-                            PublishedDate = pubDate
+                            PublishedDate = pubDate,
+                            Description = description
                         };
 
                         posts.Add(blogPost);

--- a/OurUmbraco/Community/BlogPosts/BlogPostsWebClient.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsWebClient.cs
@@ -71,6 +71,11 @@ namespace OurUmbraco.Community.BlogPosts
                                 : item.GetElementValue("link"))
                             .Trim();
 
+                        var guid = (string.IsNullOrEmpty(item.GetElementValue("guid"))
+                                ? item.GetElementValue("link")
+                                : item.GetElementValue("guid"))
+                            .Trim();
+
                         var pubDate = BlogUtils.GetPublishDate(item);
                         if (pubDate == default(DateTimeOffset))
                             continue;
@@ -118,7 +123,8 @@ namespace OurUmbraco.Community.BlogPosts
                         {
                             Channel = rssChannel,
                             Title = title,
-                            // some sites store the link in the <guid/> element 
+                            // some sites store the link in the <guid/> element
+                            Guid = guid,
                             Link = link,
                             PublishedDate = pubDate
                         };

--- a/OurUmbraco/Community/BlogPosts/BlogRssItem.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogRssItem.cs
@@ -9,12 +9,23 @@ namespace OurUmbraco.Community.BlogPosts {
         [JsonProperty("title")]
         public string Title { get; set; }
 
+        [JsonProperty("guid")]
+        public string Guid { get; set; }
+
         [JsonProperty("link")]
         public string Link { get; set; }
 
         [JsonProperty("pubDate")]
         [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTimeOffset PublishedDate { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        public bool HasDescription
+        {
+            get { return !String.IsNullOrWhiteSpace(Description); }
+        }
 
         [JsonProperty("channel")]
         public BlogRssChannel Channel { get; set; }

--- a/OurUmbraco/Community/BlogPosts/BlogRssItem.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogRssItem.cs
@@ -22,6 +22,7 @@ namespace OurUmbraco.Community.BlogPosts {
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        [JsonIgnore]
         public bool HasDescription
         {
             get { return !String.IsNullOrWhiteSpace(Description); }

--- a/OurUmbraco/Community/BlogPosts/BlogRssUtils.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogRssUtils.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Globalization;
+using System.Xml.Linq;
+using Skybrud.Essentials.Xml.Extensions;
 
 namespace OurUmbraco.Community.BlogPosts {
     
@@ -16,6 +18,55 @@ namespace OurUmbraco.Community.BlogPosts {
             // Parse a valid RFC 822 formatted date
             return DateTimeOffset.ParseExact(str, "ddd, dd MMM yyyy HH:mm:ss K", CultureInfo.InvariantCulture).ToLocalTime();
 
+        }
+        public static string GetFileExtension(string blogLogoUrl)
+        {
+            var extension = ".png";
+            var url = blogLogoUrl;
+            if (url.Contains("?"))
+                url = blogLogoUrl.Substring(0, blogLogoUrl.IndexOf("?", StringComparison.Ordinal));
+
+            var lastUrlSlug = url.Substring(url.LastIndexOf("/", StringComparison.Ordinal));
+            if (lastUrlSlug.Contains("."))
+                extension = lastUrlSlug.Substring(lastUrlSlug.LastIndexOf(".", StringComparison.Ordinal));
+            return extension;
+        }
+
+        public static string RemoveLeadingCharacters(string inString)
+        {
+            if (inString == null)
+                return null;
+
+            var substringStart = 0;
+            for (var i = substringStart; i < inString.Length; i++)
+            {
+                var character = inString[i];
+                if (character != '<')
+                    continue;
+
+                // As soon as we find the XML opening tag, break and return the rest of the string, else XElement.Parse fails
+                substringStart = i;
+                break;
+            }
+
+            return inString.Substring(substringStart);
+        }
+
+        public static DateTimeOffset GetPublishDate(XElement item)
+        {
+            var publishDate = item.GetElementValue("pubDate");
+            DateTimeOffset pubDate;
+            try
+            {
+                pubDate = Skybrud.Essentials.Time.TimeUtils.Rfc822ToDateTimeOffset(publishDate);
+            }
+            catch (Exception e)
+            {
+                // special dateformat, try normal C# date parser
+            }
+
+            DateTimeOffset.TryParse(publishDate, out pubDate);
+            return pubDate;
         }
 
     }

--- a/OurUmbraco/Community/BlogPosts/BlogUtils.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogUtils.cs
@@ -5,7 +5,8 @@ using Skybrud.Essentials.Xml.Extensions;
 
 namespace OurUmbraco.Community.BlogPosts {
     
-    public class BlogUtils {
+    public class BlogUtils
+    {
 
         public static DateTimeOffset ParseRfc822DateTime(string str) {
 

--- a/OurUmbraco/Community/BlogPosts/BlogUtils.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogUtils.cs
@@ -5,7 +5,7 @@ using Skybrud.Essentials.Xml.Extensions;
 
 namespace OurUmbraco.Community.BlogPosts {
     
-    public class BlogRssUtils {
+    public class BlogUtils {
 
         public static DateTimeOffset ParseRfc822DateTime(string str) {
 

--- a/OurUmbraco/Community/Twitter/TwitterService.cs
+++ b/OurUmbraco/Community/Twitter/TwitterService.cs
@@ -42,7 +42,7 @@ namespace OurUmbraco.Community.Twitter
                             {
                                 SearchType = SearchResultType.Recent
                             };
-                            var results = Search.SearchTweets(searchParameter);
+                            var results = Tweetinvi.Search.SearchTweets(searchParameter);
                             return results == null ? new ITweet[]{} : results.ToArray();
 
                         }, TimeSpan.FromMinutes(2));

--- a/OurUmbraco/NotificationsCore/Notifications/ScheduleHangfireJobs.cs
+++ b/OurUmbraco/NotificationsCore/Notifications/ScheduleHangfireJobs.cs
@@ -79,17 +79,13 @@ namespace OurUmbraco.NotificationsCore.Notifications
 
         public void UpdateBlogPostsJsonFile(PerformContext context)
         {
+
             // Initialize a new service
             var service = new BlogPostsService();
 
-            // Determine the path to the JSON file
-            var jsonPath = HostingEnvironment.MapPath("~/App_Data/TEMP/CommunityBlogPosts.json");
+            // Update the local storage of blog posts
+            service.UpdateBlogPosts(context);
 
-            // Generate the raw JSON
-            var rawJson = JsonConvert.SerializeObject(service.GetBlogPosts(context), Formatting.Indented);
-
-            // Save the JSON to disk
-            System.IO.File.WriteAllText(jsonPath, rawJson, Encoding.UTF8);
         }
 
 

--- a/OurUmbraco/Our/Examine/BlogItemsIndexDataService.cs
+++ b/OurUmbraco/Our/Examine/BlogItemsIndexDataService.cs
@@ -16,7 +16,7 @@ namespace OurUmbraco.Our.Examine
         {
             var service = new BlogPostsService();
 
-            var items = service.GetAllBlogItemsFromDatabase();
+            var items = service.GetBlogPosts();
 
             foreach (var item in items)
             {

--- a/OurUmbraco/Our/Examine/BlogItemsIndexDataService.cs
+++ b/OurUmbraco/Our/Examine/BlogItemsIndexDataService.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Web.Hosting;
+using Examine;
+using Examine.LuceneEngine;
+using OurUmbraco.Community.BlogPosts;
+using OurUmbraco.Documentation.Busineslogic.GithubSourcePull;
+
+namespace OurUmbraco.Our.Examine
+{
+    /// <summary>
+    /// Used to index the documentation 
+    /// </summary>
+    public class BlogItemsIndexDataService : ISimpleDataService
+    {
+
+        public IEnumerable<SimpleDataSet> GetAllData(string indexType)
+        {
+            var service = new BlogPostsService();
+
+            var items = service.GetAllBlogItemsFromDatabase();
+
+            int i = 0;
+
+            foreach (var item in items)
+            {
+                i++;
+                var simpleDataSet = new SimpleDataSet { NodeDefinition = new IndexedNode(), RowData = new Dictionary<string, string>() };
+                simpleDataSet = MapBlogItemToSimpleDataIndexItem(item, simpleDataSet, i, indexType);
+                yield return simpleDataSet;
+            }
+
+        }
+
+
+        public static SimpleDataSet MapBlogItemToSimpleDataIndexItem(BlogDatabaseItem item, SimpleDataSet simpleDataSet, int index, string indexType)
+        {
+
+            simpleDataSet.NodeDefinition.NodeId = index;
+            simpleDataSet.NodeDefinition.Type = indexType;
+
+            simpleDataSet.RowData.Add("body", String.Empty);
+            simpleDataSet.RowData.Add("nodeName", ExamineHelper.RemoveSpecialCharacters(item.Title));
+            simpleDataSet.RowData.Add("nodeTypeAlias", "blogItem");
+
+            simpleDataSet.RowData.Add("createDate", item.PublishedDate.ToString("yyyy-MM-dd HH:mm:ss"));
+            simpleDataSet.RowData.Add("updateDate", item.PublishedDate.ToString("yyyy-MM-dd HH:mm:ss"));
+
+            simpleDataSet.RowData.Add("blogId", item.BlogId);
+            simpleDataSet.RowData.Add("data", item.DataRaw);
+            simpleDataSet.RowData.Add("url", item.Data.Link);
+
+            return simpleDataSet;
+
+        }
+
+
+    }
+}

--- a/OurUmbraco/Our/Examine/BlogItemsIndexDataService.cs
+++ b/OurUmbraco/Our/Examine/BlogItemsIndexDataService.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Web.Hosting;
 using Examine;
 using Examine.LuceneEngine;
 using OurUmbraco.Community.BlogPosts;
-using OurUmbraco.Documentation.Busineslogic.GithubSourcePull;
 
 namespace OurUmbraco.Our.Examine
 {
@@ -21,23 +18,30 @@ namespace OurUmbraco.Our.Examine
 
             var items = service.GetAllBlogItemsFromDatabase();
 
-            int i = 0;
-
             foreach (var item in items)
             {
-                i++;
                 var simpleDataSet = new SimpleDataSet { NodeDefinition = new IndexedNode(), RowData = new Dictionary<string, string>() };
-                simpleDataSet = MapBlogItemToSimpleDataIndexItem(item, simpleDataSet, i, indexType);
+                simpleDataSet = MapBlogItemToSimpleDataIndexItem(item, simpleDataSet, indexType);
                 yield return simpleDataSet;
             }
 
         }
-
-
-        public static SimpleDataSet MapBlogItemToSimpleDataIndexItem(BlogDatabaseItem item, SimpleDataSet simpleDataSet, int index, string indexType)
+        public static void ReIndex(BlogDatabaseItem item)
         {
 
-            simpleDataSet.NodeDefinition.NodeId = index;
+            var simpleDataSet = new SimpleDataSet { NodeDefinition = new IndexedNode(), RowData = new Dictionary<string, string>() };
+
+            var examineNode = MapBlogItemToSimpleDataIndexItem(item, simpleDataSet, "blogItems").RowData.ToExamineXml(item.Id, "blogItems");
+
+            ExamineManager.Instance.IndexProviderCollection["BlogItemsIndexer"].ReIndexNode(examineNode, "blogItems");
+
+        }
+
+
+        public static SimpleDataSet MapBlogItemToSimpleDataIndexItem(BlogDatabaseItem item, SimpleDataSet simpleDataSet, string indexType)
+        {
+
+            simpleDataSet.NodeDefinition.NodeId = item.Id;
             simpleDataSet.NodeDefinition.Type = indexType;
 
             simpleDataSet.RowData.Add("body", String.Empty);

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -423,7 +423,7 @@
     <Compile Include="Community\BlogPosts\BlogPostsService.cs" />
     <Compile Include="Community\BlogPosts\BlogRssChannel.cs" />
     <Compile Include="Community\BlogPosts\BlogRssItem.cs" />
-    <Compile Include="Community\BlogPosts\BlogRssUtils.cs" />
+    <Compile Include="Community\BlogPosts\BlogUtils.cs" />
     <Compile Include="Community\BlogPosts\BlogDatabaseItem.cs" />
     <Compile Include="Community\GitHub\Controllers\GitHubContributorController.cs" />
     <Compile Include="Community\Controllers\MeetupsController.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -794,6 +794,7 @@
       <DependentUpon>repository.asmx</DependentUpon>
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Search\BlogItemSearchResult.cs" />
     <Compile Include="SignalRHubs\ForumPostHub.cs" />
     <Compile Include="UmbracoAuthorizationFilter.cs" />
     <Compile Include="Version\Config.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -424,6 +424,7 @@
     <Compile Include="Community\BlogPosts\BlogRssChannel.cs" />
     <Compile Include="Community\BlogPosts\BlogRssItem.cs" />
     <Compile Include="Community\BlogPosts\BlogRssUtils.cs" />
+    <Compile Include="Community\BlogPosts\BlogDatabaseItem.cs" />
     <Compile Include="Community\GitHub\Controllers\GitHubContributorController.cs" />
     <Compile Include="Community\Controllers\MeetupsController.cs" />
     <Compile Include="Community\GitHub\Models\Cached\GitHubCachedGlobalContributorModel.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -422,6 +422,7 @@
     <Compile Include="Community\BlogPosts\BlogInfo.cs" />
     <Compile Include="Community\BlogPosts\BlogPostsCache.cs" />
     <Compile Include="Community\BlogPosts\BlogPostsService.cs" />
+    <Compile Include="Community\BlogPosts\BlogPostsWebClient.cs" />
     <Compile Include="Community\BlogPosts\BlogRssChannel.cs" />
     <Compile Include="Community\BlogPosts\BlogRssItem.cs" />
     <Compile Include="Community\BlogPosts\BlogUtils.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -420,6 +420,7 @@
     <Compile Include="CamelCaseFormatter.cs" />
     <Compile Include="Community\BlogPosts\BlogCachedRssItem.cs" />
     <Compile Include="Community\BlogPosts\BlogInfo.cs" />
+    <Compile Include="Community\BlogPosts\BlogPostsCache.cs" />
     <Compile Include="Community\BlogPosts\BlogPostsService.cs" />
     <Compile Include="Community\BlogPosts\BlogRssChannel.cs" />
     <Compile Include="Community\BlogPosts\BlogRssItem.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -587,6 +587,7 @@
     <Compile Include="Our\Controllers\OurUmbracoController.cs" />
     <Compile Include="Our\CustomHandlers\PullRequestIndexer.cs" />
     <Compile Include="Our\Examine\DateRangeSearchFilter.cs" />
+    <Compile Include="Our\Examine\BlogItemsIndexDataService.cs" />
     <Compile Include="Our\Examine\PullRequestIndexDataService.cs" />
     <Compile Include="Our\Examine\ProjectPopularityPoints.cs" />
     <Compile Include="Our\Models\EditScreenshotModel.cs" />

--- a/OurUmbraco/Search/BlogItemSearchResult.cs
+++ b/OurUmbraco/Search/BlogItemSearchResult.cs
@@ -1,5 +1,6 @@
 ﻿using Examine;
 using OurUmbraco.Community.BlogPosts;
+using Skybrud.Essentials.Json;
 
 namespace OurUmbraco.Search {
 
@@ -11,11 +12,19 @@ namespace OurUmbraco.Search {
 
         public BlogInfo Blog { get; private set; }
 
-        public BlogItemSearchResult(SearchResult result, BlogRssItem item, BlogInfo blog)
+        public BlogItemSearchResult(SearchResult result, BlogInfo blog)
         {
+
             Result = result;
-            Item = item;
             Blog = blog;
+            
+            // Get the "data" field from the result
+            string rawData;
+            if (!result.Fields.TryGetValue("data", out rawData)) return;
+
+            // Parse the JSON from the search result
+            Item = JsonUtils.ParseJsonObject<BlogRssItem>(rawData);
+
         }
 
     }

--- a/OurUmbraco/Search/BlogItemSearchResult.cs
+++ b/OurUmbraco/Search/BlogItemSearchResult.cs
@@ -1,0 +1,23 @@
+﻿using Examine;
+using OurUmbraco.Community.BlogPosts;
+
+namespace OurUmbraco.Search {
+
+    public class BlogItemSearchResult {
+
+        public SearchResult Result { get; private set; }
+
+        public BlogRssItem Item { get; private set; }
+
+        public BlogInfo Blog { get; private set; }
+
+        public BlogItemSearchResult(SearchResult result, BlogRssItem item, BlogInfo blog)
+        {
+            Result = result;
+            Item = item;
+            Blog = blog;
+        }
+
+    }
+
+}

--- a/OurUmbraco/Search/BlogItemSearchResult.cs
+++ b/OurUmbraco/Search/BlogItemSearchResult.cs
@@ -25,6 +25,9 @@ namespace OurUmbraco.Search {
             // Parse the JSON from the search result
             Item = JsonUtils.ParseJsonObject<BlogRssItem>(rawData);
 
+            // Change the logo URL to the downloaded version
+            Blog.LogoUrl = $"/media/blogs/{Blog.Id}{BlogUtils.GetFileExtension(Blog.LogoUrl)}";
+
         }
 
     }


### PR DESCRIPTION
Implements parts of https://github.com/umbraco/OurUmbraco/issues/222

<hr />

There is a lot of good blog posts out there about Umbraco, so instead of just showing the most recent blog posts, this pull request introduces a searchable archive of blog posts. This means that:

- Blog posts are now stored in the `CommunityBlogItems` database table as well as added to examine via a custom `BlogItemsIndexSet` index set. This is all handled within the existing Hangfire job.

- The `MultiIndexSearcher` searcher used in the global search now also searches `BlogItemsIndexSet`. Because of this, blog posts can now be found in the global search - eg. my blog post about extracting high contrast colors.<br />
![image](https://user-images.githubusercontent.com/3634580/39892904-67bdcca0-54a2-11e8-976f-c5335966c255.png)

- A search result for a blog post is rendered by the `~/Views/Partials/Search/BlogItem.cshtml` partial view with a model of the type `BlogItemSearchResult`.

**Fallpits**

- To keep track of which RSS posts that already have been added to the archive, the update logic [pulls all existing posts from the database](https://github.com/abjerner/OurUmbraco/blob/blog-posts-search/OurUmbraco/Community/BlogPosts/BlogPostsService.cs#L55). This may become a lot of posts over time. My local DB currently has 1417 posts in it's archive 😮 

- Showing external content in the global search (and probably anywhere else on Our) might be an issue, as it isn't clear that the link will take the user away from Our. The link for a blog posts does open in a new window, but perhaps there should be a confirmation prompt to leave Our. Or just an icon indicating that the link opens in a new tab. But whether this is actually a problem depends on the HQ's stance on external links - I just thought I'd make sure to mention it ;)

**Possible further improvements**

- A JSON file is still kept with the most recent blog posts. As they are also stored in Examine, we could drop the JSON file in favor of an Examine search.

- As we can search the archive, we can also search for blog posts of a specific blog. So we could add the various blogs to the sidebar so a user can choose to see the blog posts of a single blog.<br />
![image](https://user-images.githubusercontent.com/3634580/39893454-0bf17cc6-54a4-11e8-95ad-b75978b83a3e.png)In the above example, *Umbraco HQ* is shown at the top, then followed by *24 Days In Umbraco* and *Skrift*. The remaining blogs are sorted alphabetically.<br /><br />However with a growing amount of blogs, this probably isn't the right way to show them.
