### PR TITLE
Update deprecated UserType

### DIFF
--- a/OurUmbraco/UmbracoAuthorizationFilter.cs
+++ b/OurUmbraco/UmbracoAuthorizationFilter.cs
@@ -17,7 +17,7 @@ namespace OurUmbraco
 
             var user = UmbracoContext.Current.Security.CurrentUser;
 
-            return user != null && user.UserType.Alias == "admin";
+            return user != null && user.Groups.Any(g => g.Alias == "admin");
         }
     }
 }


### PR DESCRIPTION
`UserType` property is deprecated, but we can instead access `Groups ` property and check of any of these match "admin".