### PR TITLE
Fixes issue #256: "Search" breadcrumb wrong URL

### DIFF
--- a/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
+++ b/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
@@ -9,7 +9,7 @@
             <div class="utilities">
                 <ul id="breadcrumb">
                     <li><a href="/" rel="nofollow">Our Umbraco</a></li>
-                    <li><a href="#" rel="nofollow">Search</a></li>
+                    <li><a href="@Model.Url" rel="nofollow">Search</a></li>
                     <li><a href="#" rel="nofollow">@Model.Results.SearchTerm</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
The URL should take a user back the default search page not the current search term results.

--

Upon investigation this PR by itself isn't much use. The default search page does not have a search box for a user to interact with the page.

Perhaps a great discussion is required?