### PR TITLE
Fixes Issue #260 edit new posts

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Forum/Thread.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Forum/Thread.cshtml
@@ -154,6 +154,6 @@ else
     var isMemberAdmin = memberData != null ? memberData.IsAdmin : false;
 }
 <script type="text/javascript">
-    startNotifier(@memberId, '@memberName', @Model.Id, @isMemberAdmin);
+    startNotifier(@memberId, '@memberName', @Model.Id, @isMemberAdmin.ToString().ToLower());
 </script>
 <!-- End of SignalR-->

--- a/OurUmbraco.Site/Views/Partials/Forum/Thread.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Forum/Thread.cshtml
@@ -151,8 +151,9 @@ else
     var memberData = Model.MemberData;
     var memberId = memberData != null ? memberData.Member.Id : 0;
     var memberName = memberData != null ? memberData.Member.Name : string.Empty;
+    var isMemberAdmin = memberData != null ? memberData.IsAdmin : false;
 }
 <script type="text/javascript">
-    startNotifier(@memberId, '@memberName', @Model.Id);
+    startNotifier(@memberId, '@memberName', @Model.Id, @isMemberAdmin);
 </script>
 <!-- End of SignalR-->

--- a/OurUmbraco.Site/Views/Partials/Forum/TopicForm.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Forum/TopicForm.cshtml
@@ -150,19 +150,18 @@
 
         <div class="actions">
             {{#isLoggedIn}}
-            <a href="#" data-topic="{{topicId}}" data-parent="{{id}}" data-controller="comment" class="forum-reply reply">
-                <i class="icon-Reply-arrow"></i><span>Reply</span>
-            </a>
-
-            <a href="#" class="edit-post" data-id="{{id}}" data-topic="{{topicId}}" data-controller="comment">
-                <i class="icon-Edit"></i><span>Edit</span>
-            </a>
+                <a href="#" data-topic="{{topicId}}" data-parent="{{id}}" data-controller="comment" class="forum-reply reply">
+                    <i class="icon-Reply-arrow"></i><span>Reply</span>
+                </a>
+                {{#canManageComment}}
+                <a href="#" class="edit-post" data-id="{{id}}" data-topic="{{topicId}}" data-controller="comment">
+                    <i class="icon-Edit"></i><span>Edit</span>
+                </a>
+                <a href="#" class="delete-reply" data-id="{{id}}">
+                    <i class="icon-Delete-key"></i><span>Delete post</span>
+                </a>
+                {{/canManageComment}}
             {{/isLoggedIn}}
-            {{#isCommentOwner}}
-            <a href="#" class="delete-reply" data-id="{{id}}">
-                <i class="icon-Delete-key"></i><span>Delete post</span>
-            </a>
-            {{/isCommentOwner}}
             <a href="#" class="copy-link" data-id="#{{id}}">
                 <i class="icon-Link"></i><span>Copy Link</span>
             </a>

--- a/OurUmbraco.Site/scripts/forumsignalr.js
+++ b/OurUmbraco.Site/scripts/forumsignalr.js
@@ -73,7 +73,7 @@
                 data.canHaveChildren = true;
                 data.isLoggedIn = memberId > 0;
                 data.isCommentOwner = data.authorId === memberId;
-                data.canManageComment = isMemberAdmim || data.isCommentOwner;
+                data.canManageComment = isMemberAdmin || data.isCommentOwner;
 
                 if (data.isSpam === false || data.isCommentOwner) {
                     var template = $("#comment-template").html();

--- a/OurUmbraco.Site/scripts/forumsignalr.js
+++ b/OurUmbraco.Site/scripts/forumsignalr.js
@@ -73,6 +73,7 @@
                 data.canHaveChildren = true;
                 data.isLoggedIn = memberId > 0;
                 data.isCommentOwner = data.authorId === memberId;
+                data.canManageComment = isMemberAdmim || data.isCommentOwner;
 
                 if (data.isSpam === false || data.isCommentOwner) {
                     var template = $("#comment-template").html();

--- a/OurUmbraco.Site/scripts/forumsignalr.js
+++ b/OurUmbraco.Site/scripts/forumsignalr.js
@@ -1,4 +1,4 @@
-﻿function startNotifier(memberId, memberName, modelId) {
+﻿function startNotifier(memberId, memberName, modelId, isMemberAdmin) {
     var lastActivity = null;
 
     // if it's been long since last activity, we'll remove the "working on reply" box

--- a/OurUmbraco.Site/scripts/forumsignalr.js
+++ b/OurUmbraco.Site/scripts/forumsignalr.js
@@ -71,6 +71,7 @@
                 $("#reply-is-coming").fadeOut();
 
                 data.canHaveChildren = true;
+                data.isLoggedIn = memberId > 0;
                 data.isCommentOwner = data.authorId === memberId;
 
                 if (data.isSpam === false || data.isCommentOwner) {


### PR DESCRIPTION
Hey folks,
I've done some work so that a logged in comment owner or admin can manage (read: edit or delete) a post upon creation.

This is from issue #260. Eventually we could extend this to have the topic owner involved to "Mark as Solution" but that feels outside of the scope of the PR.

Thanks,
Jamie