### PR TITLE
Updated master template and footer links to the new .com domain

### DIFF
--- a/OurUmbraco.Site/Views/Master.cshtml
+++ b/OurUmbraco.Site/Views/Master.cshtml
@@ -39,12 +39,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="alternate" type="application/rss+xml" title="Latest packages" href="//our.umbraco.org/rss/projects" />
-    <link rel="alternate" type="application/rss+xml" title="Package updates" href="//our.umbraco.org/rss/projectsupdate" />
-    <link rel="alternate" type="application/rss+xml" title="Active forum topics" href="//our.umbraco.org/rss/activetopics" />
+    <link rel="alternate" type="application/rss+xml" title="Latest packages" href="//our.umbraco.com/rss/projects" />
+    <link rel="alternate" type="application/rss+xml" title="Package updates" href="//our.umbraco.com/rss/projectsupdate" />
+    <link rel="alternate" type="application/rss+xml" title="Active forum topics" href="//our.umbraco.com/rss/activetopics" />
     <link rel="alternate" type="application/rss+xml" title="Community blogs" href="//pipes.yahoo.com/pipes/pipe.run?_id=8llM7pvk3RGFfPy4pgt1Yg&_render=rss" />
 
-    <link rel="search" type="application/opensearchdescription+xml" title="our.umbraco.org" href="/scripts/OpenSearch.xml">
+    <link rel="search" type="application/opensearchdescription+xml" title="our.umbraco.com" href="/scripts/OpenSearch.xml">
 
     <!-- Application name -->
     <meta name="application-name" content="Our Umbraco" />
@@ -76,7 +76,7 @@
             }
         }
 
-        @Model.Content.Name - our.umbraco.org
+        @Model.Content.Name - our.umbraco.com
     </title>
     <meta name="description" content="">
     <script type="text/javascript" src="/scripts/jquery-1.9.1.min.js"></script>
@@ -149,7 +149,7 @@
                     <div class="col-xs-12">
                         <p><a href="/code-of-conduct">Code Of Conduct</a> - <a href="/privacy-policy">Privacy Policy</a></p>
                         <p>&nbsp;</p>
-                        Our.umbraco.org is the community mothership for Umbraco, the open source asp.net cms. With a friendly forum for all your questions, a comprehensive documentation and a ton of packages from the community.
+                        Our.umbraco.com is the community mothership for Umbraco, the open source asp.net cms. With a friendly forum for all your questions, a comprehensive documentation and a ton of packages from the community.
                         @if (HttpContext.Current != null && HttpContext.Current.Request.UserAgent != null && HttpContext.Current.Request.UserAgent.ToLower().Contains("googlebot"))
                         {
                             <text>This site is running Umbraco.</text>


### PR DESCRIPTION
Super small update as I noticed the site footer still referenced our.umbraco.org rather than our.umbraco.com. Picked up the other domains in the master template while I was there.