### PR TITLE
Updated headline variable conditional

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -13,7 +13,8 @@
     var version = Request["version"];
     var term = Request["term"];
     var pageSize = 20;
-    var headline = orderMode == "createDate" ? "latest" : "most popular";
+    //var headline = orderMode == "createDate" ? "latest" : "most popular";
+    var headline = orderMode == "popularity" ? "most popular" : "latest";
     if (version != null)
     {
         headline = "version " + version;


### PR DESCRIPTION
Currently, the headline for both the "Updated Projects" AND "Popular Projects" filters show the same message: "Browse most popular projects"; this checks if the value passed back from `Request["orderBy"]` is actually "popularity" and assigns the corresponding message correctly.

I've commented out the old code to show that the "latest" message would never actually be shown with that logic in place.

Cheers all!