### PR TITLE
fix  #302

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_member.scss
+++ b/OurUmbraco.Client/src/scss/elements/_member.scss
@@ -4,6 +4,13 @@
 	color: $color-text;
 	margin-top: 2rem;
 
+	.forum-thread-text{
+		width: 360px;
+		@media (max-width: $xs) {
+			width: 300px;
+		}
+	}
+
 	.member-details {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
added width 360px to ".forum-thread-text" block, it makes it a stable width and prevents text from overlapping on images

https://github.com/umbraco/OurUmbraco/issues/302