### PR TITLE
Removed Fieldtype section in Forms Developer

### DIFF
--- a/OurUmbraco.Site/config/IISRewriteMaps.config
+++ b/OurUmbraco.Site/config/IISRewriteMaps.config
@@ -449,6 +449,8 @@
 		<add key="documentation/implementation/routing/pipeline" value="/documentation/implementation/Routing/Default-Routing/" />
 		<add key="documentation/implementation/routing/pipeline/ishortstringhelper" value="/documentation/Legacy/" />
 		
+		<add key="documentation/Add-ons/UmbracoForms/Developer/Field-Types" value="/documentation/Add-ons/UmbracoForms/Editor/Creating-a-form/Fieldtypes/" />
+		
 		<!-- Add-ons Courier -->
 		<add key="documentation/Add-ons/UmbracoCourier/Architecture/Index" value="/documentation/Add-ons/UmbracoCourier/" />
 		<add key="documentation/Add-ons/UmbracoCourier/Index/Developer" value="/documentation/Add-ons/UmbracoCourier/Developer/" />


### PR DESCRIPTION
Don't worry, I've just moved it to the Editor section, that already had something for it.