### PR TITLE
Update _docs.scss

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_docs.scss
+++ b/OurUmbraco.Client/src/scss/sections/_docs.scss
@@ -93,7 +93,7 @@
     background-color: $bg-color;
     border-top: 5px solid $border-color;
 
-    p:before {
+    p:first-child:before {
         font-family: icomoon,Lato,sans-serif;
         content: $icon-string;
         display: block;


### PR DESCRIPTION
Discovered a small error in this Css when you have multiple lines in a notice it makes the icon and text for each new line:
![udklip](https://user-images.githubusercontent.com/36075913/47138032-91660d80-d2b8-11e8-8bd5-01aa8cb759e7.PNG)
