### PR TITLE
Update _docs.scss

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_docs.scss
+++ b/OurUmbraco.Client/src/scss/sections/_docs.scss
@@ -85,6 +85,7 @@
     align-items: center;
     flex-wrap: wrap;
     text-decoration: none;
+    background-color: white;
 }
 
 @mixin notice($bg-color, $border-color, $icon-string) {


### PR DESCRIPTION
To avoid things like this:

![udklip](https://user-images.githubusercontent.com/36075913/47156939-79a67d80-d2e8-11e8-9f1c-b5fe8517c260.PNG)

This will make it look like this: 
![udklip](https://user-images.githubusercontent.com/36075913/47156998-9b076980-d2e8-11e8-9ede-289215514047.PNG)

Not the best fix but the markup and css is a bit hard to work with for this..
