### PR TITLE
Consistent styling for member badges

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_member.scss
+++ b/OurUmbraco.Client/src/scss/elements/_member.scss
@@ -41,9 +41,7 @@
 		}
 
 		a {
-			&:hover {
-				text-decoration: none;
-			}
+			text-decoration: none;
 		}
 
 

--- a/OurUmbraco.Client/src/scss/elements/_roles.scss
+++ b/OurUmbraco.Client/src/scss/elements/_roles.scss
@@ -1,103 +1,107 @@
 .roles {
 
-	@media (max-width: $md) {
-		display: block;
-		margin-top: .3rem;
-	}
+    @media (max-width: $md) {
+        display: block;
+        margin-top: .3rem;
+    }
 
-	span {
-		border: 2px solid $color-blue;
-		color: $color-blue;
-		font-size: .6rem;
-		font-weight: bold;
-		// border-radius: 3px;
-		padding: 2px 6px 2px;
-		display: inline-block;
+    span {
+        border: 2px solid $color-blue;
+        color: $color-blue;
+        font-size: .6rem;
+        font-weight: bold;
+        padding: 2px 6px 2px;
+        display: inline-block;
 
-		&:hover {
-			cursor: default;
-		}
+        a {
+            color: darken($color-space, 45%);
+            text-decoration: none;
 
-		+ span {
-			margin-left: 5px;
-		}
+            &:hover {
+                text-decoration: underline;
+            }
+        }
 
-		&:first-child {
-			margin-left: 0;
+        &:hover {
+            cursor: default;
+        }
 
-			@media (min-width: $md) {
-				margin-left: .3rem;
-			}
-		}
+        + span {
+            margin-left: 5px;
+        }
 
-		&.standard {
-			display: none;
-		}
+        &:first-child {
+            margin-left: 0;
 
-		&.hq {
-			border-color: $color-red;
-			color: $color-red;
-			text-transform: uppercase;
+            @media (min-width: $md) {
+                margin-left: .3rem;
+            }
+        }
 
-			// &:hover {
-			// 	background-color: rgba($color-red, .1);
-			// }
-		}
+        &.standard {
+            display: none;
+        }
 
-		&.admin {
-			border-color: $color-turquoise;
-			color: $color-turquoise;
-			text-transform: capitalize;
+        &.hq {
+            border-color: $color-red;
+            color: $color-red;
+            text-transform: uppercase;
+            // &:hover {
+            // 	background-color: rgba($color-red, .1);
+            // }
+        }
 
-			// &:hover {
-			// 	background-color: rgba($color-turquoise, .1);
-			// }
-		}
+        &.admin {
+            border-color: $color-turquoise;
+            color: $color-turquoise;
+            text-transform: capitalize;
+            // &:hover {
+            // 	background-color: rgba($color-turquoise, .1);
+            // }
+        }
 
-		&.mvp {
-			border-color: $color-roles-purple;
-			color: $color-roles-purple;
-			text-transform: uppercase;
+        &.mvp {
+            border-color: $color-roles-purple;
+            color: $color-roles-purple;
+            text-transform: uppercase;
+            // &:hover {
+            // 	background-color: rgba($color-roles-purple, .1);
+            // }
+        }
 
-			// &:hover {
-			// 	background-color: rgba($color-roles-purple, .1);
-			// }
-		}
+        &.core {
+            border-color: $color-roles-orange;
+            color: $color-roles-orange;
+            text-transform: capitalize;
+            // &:hover {
+            // 	background-color: rgba($color-roles-orange, .1);
+            // }
+        }
 
-		&.core {
-			border-color: $color-roles-orange;
-			color: $color-roles-orange;
-			text-transform: capitalize;
+        &.c-trib {
+            border-color: $color-roles-blue;
+            color: $color-roles-blue;
+            text-transform: capitalize;
+            // &:hover {
+            // 	background-color: rgba($color-roles-blue, .1);
+            // }
+        }
 
-			// &:hover {
-			// 	background-color: rgba($color-roles-orange, .1);
-			// }
-		}
+        &.corecontrib {
+            @extend .c-trib;
+            visibility: hidden;
+            position: relative;
 
-		&.c-trib {
-			border-color: $color-roles-blue;
-			color: $color-roles-blue;
-			text-transform: capitalize;
-
-			// &:hover {
-			// 	background-color: rgba($color-roles-blue, .1);
-			// }
-		}
-
-		&.corecontrib {
-			@extend .c-trib;
-			visibility: hidden;
-			position: relative;
-			&:after {
-				visibility: visible;
-				position: absolute;
-				top: -2px;
-				left: -2px;
-				display: block;
-				content: "C-trib";
-				border: inherit;
-				padding: inherit;
-			}
-		}
-	}
+            &:after {
+                visibility: visible;
+                position: absolute;
+                top: -2px;
+                left: -2px;
+                display: block;
+                content: "C-trib";
+                border: inherit;
+                padding: inherit;
+            }
+        }
+    }
 }


### PR DESCRIPTION
I've found inconsistency between styling of badges for the member on Our. It had different styles and states on various places, so I've decided to fix it.

This is how it looks now (before fix, outiside of the thread): https://cl.ly/81c4f74b0943
In the thread: https://cl.ly/9b932c75f734

---

And after small fixes..

Profile: https://cl.ly/c496799f2003
Thread: (stays same)

---

I was trying to fetch the thread styling - dunno if it's the desired / consistent one to keep. We can always get back to colored version of it as well, but I was really annoyed by the underline kept there no matter of hovering over or not.

Feedback more than welcome!