### PR TITLE
Added syntax highlighter for Markdig

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
+++ b/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
@@ -488,3 +488,51 @@
     margin: 20px 0;
   }
 }
+
+
+.highlight {
+
+    &.csharp {
+        color: #333;
+        font-size: 12px;
+        line-height: 16px;
+        .identifier { color: #dcdcaa; }
+        .keyword { color: #569cd6; }
+        .comment { color: #6a9955; }
+        .string { color: #ce9178; }
+        .constant { color: #569cd6; }
+    }
+
+    &.xml {
+        color: #333;
+        font-size: 12px;
+        line-height: 16px;
+        .cdata { color: #df5000; }
+        .cdatavalue { color: #df5000; }
+        .element { color: #63a35c; }
+        .attribute { color: #795da3; }
+        .string { color: #df5000; }
+        .quot { color: #df5000; }
+        .comment { color: #969896; }
+    }
+    
+    &.javascript {
+        color: #333;
+        font-size: 12px;
+        line-height: 16px;
+        .keyword { color: #569cd6; }
+        .constant { color: #0086b3; }
+        .string { color: #ce9178; }
+        .comment { color: #6a9955; }
+    }
+    
+    &.json {
+        color: #333;
+        font-size: 12px;
+        line-height: 16px;
+        .keyword { color: #a71d5d; }
+        .constant { color: #b5cea8; }
+        .string { color: #ce9178; }
+    }
+
+}

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -80,6 +80,9 @@
     <Reference Include="cms, Version=1.0.6837.12339, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\cms.dll</HintPath>
     </Reference>
+    <Reference Include="ColorCode, Version=1.0.1.62759, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ColorCode.1.0.1\lib\ColorCode.dll</HintPath>
+    </Reference>
     <Reference Include="controls, Version=1.0.6837.12340, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\controls.dll</HintPath>
     </Reference>
@@ -244,6 +247,12 @@
     </Reference>
     <Reference Include="Skybrud.Social.Meetup, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Skybrud.Social.Meetup.1.0.0-beta003\lib\net45\Skybrud.Social.Meetup.dll</HintPath>
+    </Reference>
+    <Reference Include="Skybrud.SyntaxHighlighter, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.1.0.2\lib\net45\Skybrud.SyntaxHighlighter.dll</HintPath>
+    </Reference>
+    <Reference Include="Skybrud.SyntaxHighlighter.Markdig, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.Markdig.1.0.0-beta001\lib\net45\Skybrud.SyntaxHighlighter.Markdig.dll</HintPath>
     </Reference>
     <Reference Include="SQLCE4Umbraco, Version=1.0.6837.12340, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\SQLCE4Umbraco.dll</HintPath>

--- a/OurUmbraco.Site/packages.config
+++ b/OurUmbraco.Site/packages.config
@@ -7,6 +7,7 @@
   <package id="ClientDependency" version="1.9.7" targetFramework="net452" />
   <package id="ClientDependency-Mvc" version="1.8.0.0" targetFramework="net451" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net452" />
+  <package id="ColorCode" version="1.0.1" targetFramework="net452" />
   <package id="Examine" version="0.1.89" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
   <package id="HtmlSanitizer" version="4.0.185" targetFramework="net452" />
@@ -72,6 +73,8 @@
   <package id="Skybrud.Social.Core" version="1.0.10" targetFramework="net452" />
   <package id="Skybrud.Social.GitHub" version="1.0.0-beta003" targetFramework="net452" />
   <package id="Skybrud.Social.Meetup" version="1.0.0-beta003" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter" version="1.0.2" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter.Markdig" version="1.0.0-beta001" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
   <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net452" />

--- a/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
+++ b/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
+using Skybrud.SyntaxHighlighter.Markdig;
 
 
 namespace OurUmbraco.Documentation.Busineslogic
@@ -61,6 +62,7 @@ namespace OurUmbraco.Documentation.Busineslogic
                     .UseTaskLists()
                     .UseDiagrams()
                     .UseAutoLinks()
+                    .UseSyntaxHighlighter()
                     .Build();
 
                 var transform = Markdown.ToHtml(clean, pipeline);

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -64,6 +64,9 @@
     <Reference Include="cms, Version=1.0.6837.12339, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\cms.dll</HintPath>
     </Reference>
+    <Reference Include="ColorCode, Version=1.0.1.62759, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ColorCode.1.0.1\lib\ColorCode.dll</HintPath>
+    </Reference>
     <Reference Include="controls, Version=1.0.6837.12340, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\controls.dll</HintPath>
     </Reference>
@@ -263,6 +266,12 @@
     </Reference>
     <Reference Include="Skybrud.Social.Vimeo, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Skybrud.Social.Vimeo.1.0.0-beta003\lib\net45\Skybrud.Social.Vimeo.dll</HintPath>
+    </Reference>
+    <Reference Include="Skybrud.SyntaxHighlighter, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.1.0.2\lib\net45\Skybrud.SyntaxHighlighter.dll</HintPath>
+    </Reference>
+    <Reference Include="Skybrud.SyntaxHighlighter.Markdig, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.Markdig.1.0.0-beta001\lib\net45\Skybrud.SyntaxHighlighter.Markdig.dll</HintPath>
     </Reference>
     <Reference Include="SQLCE4Umbraco, Version=1.0.6837.12340, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\SQLCE4Umbraco.dll</HintPath>

--- a/OurUmbraco/packages.config
+++ b/OurUmbraco/packages.config
@@ -7,6 +7,7 @@
   <package id="ClientDependency" version="1.9.7" targetFramework="net452" />
   <package id="ClientDependency-Mvc" version="1.8.0.0" targetFramework="net451" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net452" />
+  <package id="ColorCode" version="1.0.1" targetFramework="net452" />
   <package id="Examine" version="0.1.89" targetFramework="net452" />
   <package id="gitter-api-pcl" version="1.0.0-preview2" targetFramework="net452" />
   <package id="Hangfire" version="1.6.19" targetFramework="net452" />
@@ -77,6 +78,8 @@
   <package id="Skybrud.Social.Google" version="1.0.0-beta004" targetFramework="net452" />
   <package id="Skybrud.Social.Meetup" version="1.0.0-beta003" targetFramework="net452" />
   <package id="Skybrud.Social.Vimeo" version="1.0.0-beta003" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter" version="1.0.2" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter.Markdig" version="1.0.0-beta001" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />


### PR DESCRIPTION
A follow up on https://issues.umbraco.org/issue/OUR-290

In my original issue listed above, I described my package [**Skybrud.SyntaxHighlighter**](https://github.com/abjerner/Skybrud.SyntaxHighlighter) which supports syntax highlighting for a few different languages - including C#.

Like Our is now, I'm using Markdig for some of my internal projects, so I've also created a [**Skybrud.SyntaxHighlighter.Markdig**](https://github.com/abjerner/Skybrud.SyntaxHighlighter.Markdig) package which adds syntax highlighting support to fenced code blocks (three back ticks).

With this PR, this is now added to Our Umbraco as well 🎉 

One of the reasons why I created my own package, was because the old [**ColorCode**](https://archive.codeplex.com/?p=colorcode) (the one used by CodePlex and other Microsoft sites) had hardcoded colors, and also a few bugs there and there, and it is no longer in actively development. I've also haven't been able to find a better C#-based alternative.

My package still builds on top of ColorCode for most of the supported languages, but makes sure to to replace the hardcoded HEX color values with CSS class names that can be styled instead. This makes sure the colors can be customized to fit the dark code boxes of Our Umbraco.

So for C#, a fenced code block will now look like:

![image](https://user-images.githubusercontent.com/3634580/47608331-1923e880-da2c-11e8-90f1-ca9b5be27f23.png)

and for JSON and JavaScript respectively:

![image](https://user-images.githubusercontent.com/3634580/47608339-3ce72e80-da2c-11e8-87f1-8c60f8e587e9.png)

ColorCode doesn't have a highlighter for JSON, but uses the highlighter for JavaScript instead - but that one has a bug with escaping double quotes.

I have therefore written my own highlighter for JSON, so JSON is now properly handled. JavaScript is still handled by ColorCode's highlighter, which can be seen from the screenshot above.

My plan for my package is to eventually get rid of ColorCode entirely - eg. to get rid of the various bugs. But for now, I hope this PR can be merged so we can get syntax highlighting on Our Umbraco. For now, my PR specifically target's the documentation.