### PR TITLE
Change to topic form icon from download to a down arrow

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Forum/TopicForm.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Forum/TopicForm.cshtml
@@ -88,7 +88,7 @@
             </div>
         </div>
     </div>
-    <span class="markdown-close icon-Page-down"></span>
+    <span class="markdown-close icon-Navigation-down"></span>
     <div class="draft">Draft</div>
 </div>
 


### PR DESCRIPTION
This minimise button looks so much like a download button that it's actually pretty misleading. I've changed the icon to a downward triangle so it's easier for a first time user to know what they can do here. 