### PR TITLE
Would .info and .notice make sense as well?

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_docs.scss
+++ b/OurUmbraco.Client/src/scss/sections/_docs.scss
@@ -116,6 +116,13 @@
         @include notice(rgba(40,51,204,.07), rgba(40,51,204,.70), "\e148  Tip:");
     }
 
+    .info {
+        @include notice(rgba(40,51,204,.07), rgba(40,51,204,.70), "\e148  Info:");
+    }
+     .notice {
+        @include notice(rgba(40,51,204,.07), rgba(40,51,204,.70), "\e148  Notice:");
+    }
+
     .checklist {
         ul {
             list-style: none;


### PR DESCRIPTION
I have a specific case for the documentation where I'm describing that a feature isn't available in earlier versions of Umbraco. I don't really feel *Tip* is the best title here, so my perhaps we should add `.info` and `.notice` as well?

![image](https://user-images.githubusercontent.com/3634580/47749684-ebd67500-dc8d-11e8-9fc3-b0442f5289ba.png)

I'm not that familiar with the `:::` syntax. Would it be possible to specify the title via Markdown syntax?