### PR TITLE
Include "Version" attribute in TopicController

### DIFF
--- a/OurUmbraco/Forum/Api/TopicController.cs
+++ b/OurUmbraco/Forum/Api/TopicController.cs
@@ -16,6 +16,7 @@ namespace OurUmbraco.Forum.Api
             t.MemberId = Members.GetCurrentMemberId();
             t.Created = DateTime.Now;
             t.ParentId = model.Forum;
+            t.Version = model.Version;
             TopicService.Save(t);
         }
 


### PR DESCRIPTION
#324 - Hopefully a step closer to finding a solution. It seems that all of the other model attributes (located at https://github.com/umbraco/OurUmbraco/blob/master/OurUmbraco/Forum/Models/TopicSaveModel.cs) are called in the Post method while Version has been left out for some reason. Apologies if this isn't helpful but I'd be keen to understand why it's been left out of the controller despite being included in the model?