### PR TITLE
Increasing the db connection timeout in template web.config

### DIFF
--- a/OurUmbraco.Site/web.template.config
+++ b/OurUmbraco.Site/web.template.config
@@ -149,7 +149,7 @@
     </appSettings>
     <connectionStrings>
         <remove name="umbracoDbDSN" />
-        <add name="umbracoDbDSN" connectionString="server=.\SQLExpress;database=our.umbraco.org.live.v7;user id=sa;password=abc123" providerName="System.Data.SqlClient" />
+        <add name="umbracoDbDSN" connectionString="server=.\SQLExpress;database=our.umbraco.org.live.v7;user id=sa;password=abc123;Connection Timeout=300" providerName="System.Data.SqlClient" />
         <!-- Important: If you're upgrading Umbraco, do not clear the connection string / provider name during your web.config merge. -->
     </connectionStrings>
     <system.data>


### PR DESCRIPTION
When first getting the Our website to run locally the database reported timeout issues as it has a lot of upgrading/migrations to do.  The default connection timeout is 15 seconds.  I've set it to be 5 minutes in the template web.config.