### PR TITLE
Improved colors for XML syntax highlighting

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
+++ b/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
@@ -490,7 +490,7 @@
 }
 
 
-.highlight {
+.markdown-syntax .highlight {
 
     &.csharp {
         color: #333;
@@ -507,13 +507,14 @@
         color: #333;
         font-size: 12px;
         line-height: 16px;
-        .cdata { color: #df5000; }
-        .cdatavalue { color: #df5000; }
-        .element { color: #63a35c; }
-        .attribute { color: #795da3; }
-        .string { color: #df5000; }
-        .quot { color: #df5000; }
-        .comment { color: #969896; }
+        pre { color: #858585; }
+        .cdata { color: #ce9178; }
+        .cdatavalue { color: #ce9178; }
+        .element { color: #569cd6; }
+        .attribute { color: #8cdcfe; }
+        .string { color: #ce9178; }
+        .quot { color: #ce9178; }
+        .comment { color: #6a9955; }
     }
     
     &.javascript {


### PR DESCRIPTION
Seems I didn't test the colors for XML syntax highlighting for my other PR, as the colors are better for light themes. So with this PR, I'm turning:

![image](https://user-images.githubusercontent.com/3634580/48518606-6bf20280-e86a-11e8-9bad-cca2a8371a50.png)

into:

![image](https://user-images.githubusercontent.com/3634580/48518594-64caf480-e86a-11e8-8a3c-3261f5c0ec75.png)

The latter is based on the default theme from VS Code, which has a dark background similar to the Our forum.