### PR TITLE
Updated the syntax highlighter

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
+++ b/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
@@ -534,6 +534,7 @@
         .keyword { color: #a71d5d; }
         .constant { color: #b5cea8; }
         .string { color: #ce9178; }
+        .comment { color: #6a9955; }
     }
 
 }

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -252,11 +252,11 @@
       <HintPath>..\packages\Skybrud.Social.Twitter.1.0.0-beta006\lib\net45\Skybrud.Social.Twitter.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Skybrud.SyntaxHighlighter, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Skybrud.SyntaxHighlighter.1.0.2\lib\net45\Skybrud.SyntaxHighlighter.dll</HintPath>
+    <Reference Include="Skybrud.SyntaxHighlighter, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.1.0.4\lib\net45\Skybrud.SyntaxHighlighter.dll</HintPath>
     </Reference>
     <Reference Include="Skybrud.SyntaxHighlighter.Markdig, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Skybrud.SyntaxHighlighter.Markdig.1.0.0-beta001\lib\net45\Skybrud.SyntaxHighlighter.Markdig.dll</HintPath>
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.Markdig.1.0.0-beta003\lib\net45\Skybrud.SyntaxHighlighter.Markdig.dll</HintPath>
     </Reference>
     <Reference Include="SQLCE4Umbraco, Version=1.0.6837.12340, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\SQLCE4Umbraco.dll</HintPath>

--- a/OurUmbraco.Site/packages.config
+++ b/OurUmbraco.Site/packages.config
@@ -74,8 +74,8 @@
   <package id="Skybrud.Social.GitHub" version="1.0.0-beta003" targetFramework="net452" />
   <package id="Skybrud.Social.Meetup" version="1.0.0-beta003" targetFramework="net452" />
   <package id="Skybrud.Social.Twitter" version="1.0.0-beta006" targetFramework="net452" />
-  <package id="Skybrud.SyntaxHighlighter" version="1.0.2" targetFramework="net452" />
-  <package id="Skybrud.SyntaxHighlighter.Markdig" version="1.0.0-beta001" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter" version="1.0.4" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter.Markdig" version="1.0.0-beta003" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
   <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net452" />

--- a/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
+++ b/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
+using Skybrud.SyntaxHighlighter;
 using Skybrud.SyntaxHighlighter.Markdig;
 
 
@@ -62,8 +63,10 @@ namespace OurUmbraco.Documentation.Busineslogic
                     .UseTaskLists()
                     .UseDiagrams()
                     .UseAutoLinks()
-                    .UseSyntaxHighlighter()
+                    .UseSyntaxHighlighter(out SyntaxHighlighterOptions highligther)
                     .Build();
+
+                highligther.AddAlias("json5", Language.Json);
 
                 var transform = Markdown.ToHtml(clean, pipeline);
 

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -274,11 +274,11 @@
     <Reference Include="Skybrud.Social.Vimeo, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Skybrud.Social.Vimeo.1.0.0-beta003\lib\net45\Skybrud.Social.Vimeo.dll</HintPath>
     </Reference>
-    <Reference Include="Skybrud.SyntaxHighlighter, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Skybrud.SyntaxHighlighter.1.0.2\lib\net45\Skybrud.SyntaxHighlighter.dll</HintPath>
+    <Reference Include="Skybrud.SyntaxHighlighter, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.1.0.4\lib\net45\Skybrud.SyntaxHighlighter.dll</HintPath>
     </Reference>
     <Reference Include="Skybrud.SyntaxHighlighter.Markdig, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Skybrud.SyntaxHighlighter.Markdig.1.0.0-beta001\lib\net45\Skybrud.SyntaxHighlighter.Markdig.dll</HintPath>
+      <HintPath>..\packages\Skybrud.SyntaxHighlighter.Markdig.1.0.0-beta003\lib\net45\Skybrud.SyntaxHighlighter.Markdig.dll</HintPath>
     </Reference>
     <Reference Include="SQLCE4Umbraco, Version=1.0.6837.12340, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.12.3\lib\net45\SQLCE4Umbraco.dll</HintPath>

--- a/OurUmbraco/packages.config
+++ b/OurUmbraco/packages.config
@@ -80,8 +80,8 @@
   <package id="Skybrud.Social.Meetup" version="1.0.0-beta003" targetFramework="net452" />
   <package id="Skybrud.Social.Twitter" version="1.0.0-beta006" targetFramework="net452" />
   <package id="Skybrud.Social.Vimeo" version="1.0.0-beta003" targetFramework="net452" />
-  <package id="Skybrud.SyntaxHighlighter" version="1.0.2" targetFramework="net452" />
-  <package id="Skybrud.SyntaxHighlighter.Markdig" version="1.0.0-beta001" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter" version="1.0.4" targetFramework="net452" />
+  <package id="Skybrud.SyntaxHighlighter.Markdig" version="1.0.0-beta003" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />


### PR DESCRIPTION
As the JSON examples used throughout the documentation doesn't follow the JSON specification 100%, I realized I had to adjust my syntax highlighter package a bit (see some discussion [here](https://github.com/umbraco/UmbracoDocs/pull/1250)).

Where the old version of my package used the old ColorCode from Microsoft (which had some bugs on it's own), I decided to write my own JSON tokenizer/parser, which then gives a number of benefits - eg. comments and strings that are not properly enclosed with double quotes.

As GitHub doesn't like invalid JSON either, @jmayntzhusen suggested we could use `json5` (human friendly JSON, that is) instead of `json`, I've also updated my Markdig extension and the code for Our to allow setting `json5` as an alias of JSON.