### PR TITLE
Make search titles more friendly in the documentation

### DIFF
--- a/OurUmbraco.Site/Views/Master.cshtml
+++ b/OurUmbraco.Site/Views/Master.cshtml
@@ -75,7 +75,7 @@
                 {
                     var path = title.Split(new string[] { " - " }, StringSplitOptions.None);
 
-                    System.Globalization.TextInfo myTI = new System.Globalization.CultureInfo("en-US", false).TextInfo;
+                    var textInfo = new System.Globalization.CultureInfo("en-US", false).TextInfo;
 
                     var firstUrlPath = myTI.ToTitleCase(path[0]);
                     var lastUrlPath = myTI.ToTitleCase(path[path.Length - 1]);


### PR DESCRIPTION
This will make a page like: 
https://our.umbraco.com/documentation/getting-started/setup/install/system-requirements

That has a title like this: 
system-requirements - install - setup - getting-started - Documentation - our.umbraco.com

Turn into something like this:
System-Requirements, Getting-Started - Our Umbraco

So search results will look a bit nicer than this:
![image](https://user-images.githubusercontent.com/36075913/49807058-71534780-fd59-11e8-8468-2daa0823b367.png)


Long term we want to change how this works with https://github.com/umbraco/OurUmbraco/pull/361

But for now this can make it better in the meantime
    