### PR TITLE
Fixing the Release Compare Issue tracker URL's.

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Releases/ReleasesDropdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Releases/ReleasesDropdown.cshtml
@@ -178,9 +178,10 @@
 
                                 foreach (var issue in releaseFeatures)
                                 {
+                                    var url = issue.Source == ReleaseSource.YouTrack ? $"https://issues.umbraco.org/issue/{issue.Id}" : $"https://github.com/umbraco/Umbraco-CMS/issues/{issue.Id}";
                                     <ul>
                                         <li class="@issue.State.StateIcon()" title="@issue.State">
-                                            <a href="http://issues.umbraco.org/issue/@(issue.Id)" target="_blank">@issue.Id - @issue.Title</a>
+                                            <a href="@(url)" target="_blank">@issue.Id - @issue.Title</a>
                                         </li>
                                     </ul>
                                 }
@@ -202,9 +203,10 @@
 
                                 foreach (var issue in breakingInRelease)
                                 {
+                                    var url = issue.Source == ReleaseSource.YouTrack ? $"https://issues.umbraco.org/issue/{issue.Id}" : $"https://github.com/umbraco/Umbraco-CMS/issues/{issue.Id}";
                                     <ul>
                                         <li class="@issue.State.StateIcon()" title="@issue.State">
-                                            <a href="http://issues.umbraco.org/issue/@(issue.Id)" target="_blank">@issue.Id - @issue.Title</a>
+                                            <a href="@(url)" target="_blank">@issue.Id - @issue.Title</a>
                                         </li>
                                     </ul>
                                 }
@@ -225,9 +227,11 @@
                                 <h3>Issues & Tasks fixed in version @release.Version</h3>
                                 foreach (var issue in issuesFixedInRelease)
                                 {
+                                    var url = issue.Source == ReleaseSource.YouTrack ? $"https://issues.umbraco.org/issue/{issue.Id}" : $"https://github.com/umbraco/Umbraco-CMS/issues/{issue.Id}";
+
                                     <ul>
-                                        <li class="@issue.State.StateIcon()" title="@issue.State.">
-                                            <a href="http://issues.umbraco.org/issue/@(issue.Id)" target="_blank">@issue.Id - @issue.Title</a>
+                                        <li class="@issue.State.StateIcon()" title="@issue.State">
+                                            <a href="@(url)" target="_blank">@issue.Id - @issue.Title</a>
                                         </li>
                                     </ul>
                                 }

--- a/OurUmbraco/Our/Models/Releases.cs
+++ b/OurUmbraco/Our/Models/Releases.cs
@@ -82,10 +82,15 @@ namespace OurUmbraco.Our.Models
             public bool Breaking { get; set; }
 
             [JsonProperty("source")]
-            public string Source { get; set; }
+            public ReleaseSource Source { get; set; }
 
             [JsonIgnore]
             public string Resolved { get; set; }
         }
+    }
+    public enum ReleaseSource
+    {
+        YouTrack,
+        GitHub
     }
 }

--- a/OurUmbraco/Our/Services/ReleasesService.cs
+++ b/OurUmbraco/Our/Services/ReleasesService.cs
@@ -29,7 +29,7 @@ namespace OurUmbraco.Our.Services
         public List<Release> GetReleasesCache()
         {
             ApplicationContext.Current.ApplicationCache.RuntimeCache
-                .GetCacheItem(ReleasesCacheCacheKey, () => ReleasesCache(), TimeSpan.FromHours(2));
+                .GetCacheItem(ReleasesCacheCacheKey, () => ReleasesCache(), TimeSpan.FromSeconds(30));
             return (List<Release>)ApplicationContext.Current.ApplicationCache.RuntimeCache
                 .GetCacheItem(ReleasesCacheCacheKey);
         }
@@ -154,7 +154,7 @@ namespace OurUmbraco.Our.Services
                             State = issue.State,
                             Title = issue.IssueTitle,
                             Type = issue.Type,
-                            Source = "YouTrack"
+                            Source = ReleaseSource.YouTrack
                         });
                     }
                 }
@@ -229,7 +229,7 @@ namespace OurUmbraco.Our.Services
                         State = state,
                         Title = item.Title,
                         Type = type,
-                        Source = "GitHub"
+                        Source = ReleaseSource.GitHub
                     });
                 }
             }

--- a/OurUmbraco/Our/Services/ReleasesService.cs
+++ b/OurUmbraco/Our/Services/ReleasesService.cs
@@ -29,7 +29,7 @@ namespace OurUmbraco.Our.Services
         public List<Release> GetReleasesCache()
         {
             ApplicationContext.Current.ApplicationCache.RuntimeCache
-                .GetCacheItem(ReleasesCacheCacheKey, () => ReleasesCache(), TimeSpan.FromSeconds(30));
+                .GetCacheItem(ReleasesCacheCacheKey, () => ReleasesCache(), TimeSpan.FromHours(2));
             return (List<Release>)ApplicationContext.Current.ApplicationCache.RuntimeCache
                 .GetCacheItem(ReleasesCacheCacheKey);
         }


### PR DESCRIPTION
The release compare page now links to either the YouTrack issue or the GitHub issue based on it's source.

Issue: #345 