### PR TITLE
Small fix for the icons shown in the package search results.

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_packages.scss
+++ b/OurUmbraco.Client/src/scss/elements/_packages.scss
@@ -86,8 +86,8 @@ body.packages {
 		}
 
 		img {
-			max-width: 64px;
-			max-height: 64px;
+            max-width: 100%;
+            height: auto;
 			display: block;
 			vertical-align: middle;
 			

--- a/OurUmbraco.Client/src/scss/elements/_packages.scss
+++ b/OurUmbraco.Client/src/scss/elements/_packages.scss
@@ -86,8 +86,8 @@ body.packages {
 		}
 
 		img {
-			max-width: 100%;
-			height: auto;
+			max-width: 64px;
+			max-height: 64px;
 			display: block;
 			vertical-align: middle;
 			

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -141,7 +141,7 @@
         <div class="row">
             <div class="col-xs-2 col-md-1">
                 {[ if (image != null) { ]}
-                <img src="{{image}}" alt="">
+                <img src="{{image}}?bgcolor=fff&width=64&height=64&format=png" srcset="{{image}}?bgcolor=fff&width=128&height=128&format=png 2x,{{image}}?bgcolor=fff&width=192&height=192&format=png 3x" alt="">
                 {[ } else { ]}
                 <i class='icon-Box'></i>
                 {[ } ]}
@@ -188,9 +188,9 @@
                                 defaultScreenshot = childContent.GetPropertyValue("defaultScreenshotPath", false, "/css/img/package2.png");
                             }
                         }
-                        <img src="@Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=50&height=50&format=png"
-                             srcset="@Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=100&height=100&format=png 2x,
-             @Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=150&height=150&format=png 3x" />
+                        <img src="@Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=64&height=64&format=png"
+                             srcset="@Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=128&height=128&format=png 2x,
+             @Utils.GetScreenshotPath(defaultScreenshot)?bgcolor=fff&width=192&height=192&format=png 3x" />
                     </div>
                     <div class="col-xs-10 col-md-6">
                         <div class="forum-thread-text">


### PR DESCRIPTION
This is a fix for issue #320 

Rather than cropping as the ticket suggested, I have just set the max height and width to be 64px square as this was already the max width. The problem with setting a crop is the package owner would have no control over how their image is cropped. This way, we can inform package owners of the exact dimensions and it's up to them to upload an image that works.