### PR TITLE
Fixed issue with GitHub usernames

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Members/PublicProfile.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/PublicProfile.cshtml
@@ -32,11 +32,17 @@
         // Make the search in examine
         ISearchResults results = searcher.Search(criteria);
 
-        // Get the member based on the ID from the search result
-        if (results.TotalItemCount > 0)
+        // Search may reveal partial matches, so we need to do an extra check in C#
+        foreach (SearchResult result in results)
         {
-            member = Members.GetById(results.First().Id);
+            string github;
+            if (result.Fields.TryGetValue("github", out github) && String.Equals(username, github, StringComparison.InvariantCultureIgnoreCase))
+            {
+                member = Members.GetById(result.Id);
+                break;
+            }
         }
+    
     }
 
     if (member == null)

--- a/OurUmbraco.Site/web.template.config
+++ b/OurUmbraco.Site/web.template.config
@@ -482,7 +482,7 @@
                   <action type="Rewrite" url="member/?id={R:1}" />
                 </rule>
                 <rule name="MemberProfileUsername">
-                  <match url="^members/(\w+)" />
+                  <match url="^members/([\w-]+)(|/)$" />
                   <action type="Rewrite" url="member/?username={R:1}" />
                 </rule>
                 <rule name="MVCTemplatingDocs">


### PR DESCRIPTION
Reported here: https://twitter.com/waltza86/status/1084047844464570368

The issue was caused by two bugs:

**IIS rewrite rule**
The rewrite rule would match usernames against `(\w+)`. `\w` is short for `a-zA-Z0-9_`, which doesn't include hyphens. The regex also didn't wrap to the end of the line, which was why it still matched `Matthew` even though the URL contained `Matthew-Wise`. Both should be fixed now.

**Search in Examine**
The search in Examine may reveal partial matches. So when searching for `github:Matthew`, Examine would return more than one result, and we would just pick the first and display the profile for that member.

With the PR, we're doing an extra check in C#/Razor to verify show the profile for the correct member.