### PR TITLE
Fix typo in GitHub label description

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Members/Register.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/Register.cshtml
@@ -45,7 +45,7 @@
 
             <div class="profile-input" id="github-alias">
                 @Html.LabelFor(m => m.GitHubUsername)
-                <em>We'd love to show of your GitHub contributions to the community.</em>
+                <em>We'd love to show off your GitHub contributions to the community.</em>
                 @Html.TextBoxFor(m => m.GitHubUsername)
             </div>
 


### PR DESCRIPTION
Noticed a typo when signing up. So thought I would fix it!