### PR TITLE
Changes for v8 documentation

### DIFF
--- a/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
+++ b/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
@@ -98,8 +98,8 @@
                                 <label for="search">Search for documentation</label>
                             </div>
                             <select class="version-search-select">
-                                <option value="8">v8</option>
-                                <option value="7" selected="selected">v7</option>
+                                <option value="8" selected="selected">v8</option>
+                                <option value="7">v7</option>
                                 <option value="6">v6</option>
                             </select>
                         </div>

--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -146,7 +146,7 @@
         <add key="GitHubClientSecret" value="#{GitHubClientSecret}#" />
 		
         <!-- Documentation -->
-        <add key="Documentation:CurrentMajorVersion" value="7" />
+        <add key="Documentation:CurrentMajorVersion" value="8" />
 
         <!-- Upcoming features -->
         <add key="UnhideUpcomingFeatures" value="false"/>

--- a/OurUmbraco/Our/Examine/ExamineHelper.cs
+++ b/OurUmbraco/Our/Examine/ExamineHelper.cs
@@ -159,7 +159,7 @@ namespace OurUmbraco.Our.Examine
             else
             {
                 // no YAML information, add the current version as majorVersion
-                simpleDataSet.RowData.Add("majorVersion", GetCurrentDocVersion().ToString());
+                simpleDataSet.RowData.Add("majorVersion", "7 8");
             }
             return secondYamlMarker;
         }

--- a/OurUmbraco/Our/Examine/OurSearcher.cs
+++ b/OurUmbraco/Our/Examine/OurSearcher.cs
@@ -73,13 +73,12 @@ namespace OurUmbraco.Our.Examine
                 ? ConfigurationManager.AppSettings[Constants.AppSettings.DocumentationCurrentMajorVersion]
                 : MajorDocsVersion.ToString();
 
-            //we filter by this version by excluding the other major versions in lucene so
-            var versionsToNegate = currentMajorVersions.Where(f => f != versionToFilterBy).ToArray<string>();
-            foreach (var versionToNegate in versionsToNegate)
+            // filter to the majorVersion
+            if (string.IsNullOrEmpty(versionToFilterBy) == false)
             {
-                sb.AppendFormat("-majorVersion:{0} ", versionToNegate);
+                sb.AppendFormat("+majorVersion:{0} ", versionToFilterBy);
             }
-            
+
             if (!string.IsNullOrEmpty(Term))
             {
                 sb.Append("+(");


### PR DESCRIPTION
These changes will index all non-versioned articles as both v7 and 8. Set the default search bar to v8.

This will be accompanied by a Docs pull request renaming all index-v8.md files to index.md, and a few other small things. Will reference it here once it is done.

**This is not to be merged before the v8 launch**