### PR TITLE
cross search version 7 and 8 on umbraco docs

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_docs.scss
+++ b/OurUmbraco.Client/src/scss/sections/_docs.scss
@@ -86,6 +86,8 @@
     flex-wrap: wrap;
     text-decoration: none;
     background-color: white;
+    z-index: 1;
+    position: relative;
 }
 
 @mixin notice($bg-color, $border-color, $icon-string) {

--- a/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
+++ b/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
@@ -1,15 +1,15 @@
-﻿@inherits UmbracoTemplatePage
+﻿﻿@inherits UmbracoTemplatePage
 @using OurUmbraco.Repository.Services
 @{
     Layout = "~/Views/Master.cshtml";
+
+    var docVersionService = new DocumentationVersionService();
+    var currentVersion = docVersionService.GetCurrentMajorVersion();
+    var altVersions = docVersionService.GetAlternateDocumentationVersions(Request.Url, true);
+
+    var currentDocVersion = altVersions.Where(x => x.IsCurrentPage).FirstOrDefault();
 }
 @section SeoMetaData {
-    @{
-        var docVersionService = new DocumentationVersionService();
-        var altVersions = docVersionService.GetAlternateDocumentationVersions(Request.Url, true);
-
-        var currentDocVersion = altVersions.Where(x => x.IsCurrentPage).FirstOrDefault();
-    }
     @if (currentDocVersion != null)
     {
         if (currentDocVersion.MetaTitle != null)
@@ -52,8 +52,8 @@
         //If no description is set this will just be empty - which is what it used to be anyways, could think of adding some sort of fallback?
         <meta name="description" content="@currentDocVersion.MetaDescription" />
     }
-                    else
-                    {
+    else
+    {
         <title>
             @{
                 var title = string.Empty;
@@ -68,7 +68,6 @@
                     <text>@title - </text>
                 }
             }
-
             @Model.Content.Name - our.umbraco.com
         </title>
         <meta name="description" content="">
@@ -84,44 +83,37 @@
                     </div><!-- .content-wrapper -->
                 </div><!-- .sidebar-content -->
             </div><!-- .sidebar-area-->
-
             <div class="main-area">
                 <div class="main-content">
                     <div class="content-wrapper">
                         <div>
                             @Html.Partial("~/Views/Partials/Documentation/Breadcrumb.cshtml")
                         </div>
-
                         <div class="search-big">
                             <div class="textSearch">
                                 <input type="search" class="docs-search-input" required placeholder="Search for documentation">
                                 <label for="search">Search for documentation</label>
                             </div>
                             <select class="version-search-select">
-                                <option value="8">v8</option>
-                                <option value="7" selected="selected">v7</option>
-                                <option value="6">v6</option>
+                                <option value="8" selected="@(currentVersion == "8"? "selected" : null)">v8</option>
+                                <option value="7" selected="@(currentVersion == "7"? "selected" : null)">v7</option>
+                                <option value="6" selected="@(currentVersion == "6"? "selected" : null)">v6</option>
                             </select>
                         </div>
-
                         <ul class="search-all-results docs-search-listing"></ul>
-
                         <div id="markdown-docs" class="docs-default-listing markdown-syntax">
                             @Html.Partial("~/Views/Partials/Documentation/DisplayMarkdown.cshtml")
                         </div>
                     </div><!-- .content-wrapper -->
                 </div><!-- .main-content -->
             </div><!-- .main-area -->
-
         </div><!-- .page-content -->
-
         <script type="text/template" class="search-item-docs">
             <li>
                 <a href="{{ url }}">
                     <div class="type-icon">
                         <i class="icon-Book-alt"></i>
                     </div>
-
                     <div class="type-context">
                         <div class="type-name">
                             {{ name }}

--- a/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
@@ -1,4 +1,5 @@
 @using OurUmbraco.Documentation.Busineslogic
+@using OurUmbraco.Repository.Models
 @using OurUmbraco.Repository.Services
 @inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 
@@ -83,9 +84,12 @@
     var markdown = ml.DoTransformation();
     // method to determine if alternate versions exist for these docs
     var docVersionService = new DocumentationVersionService();
-    var altVersions = docVersionService.GetAlternateDocumentationVersions(Request.Url);// method to determine which alternate versions exist of this page
-                                                                                       //bool hasAltVersions = altVersions.Any(av => av.IsCurrentVersion == true);  // do we want to indicate future versions in a different colour, or am I making this toooo complicated
-    bool hasAltVersions = altVersions.Any();  // do we want to indicate future versions in a different colour, or am I making this toooo complicated
+    var altVersions = docVersionService.GetAlternateDocumentationVersions(Request.Url).ToList();// method to determine which alternate versions exist of this page
+    var hasAltVersions = altVersions.Any();  // do we want to indicate future versions in a different colour, or am I making this toooo complicated
+
+    var currentVersion = docVersionService.GetAlternateDocumentationVersions(Request.Url, true).SingleOrDefault(x => x.IsCurrentPage);
+    var currentVersionIsRemovedForv8 = currentVersion != null && currentVersion.VersionRemoved != null && currentVersion.VersionRemoved.StartsWith("8");
+    var currentUmbracoVersion = int.Parse(docVersionService.GetCurrentMajorVersion());
 }
 
 @if (hasAltVersions)
@@ -119,4 +123,68 @@
         </div>
     </aside>
 }
+
+@if (string.IsNullOrWhiteSpace(Request.QueryString["debug"]) == false)
+{
+    <table>
+        @if (currentVersion != null)
+        {
+            <tr>
+                <td>Version from (major)</td>
+                <td> @currentVersion.VersionFrom.Major</td>
+            </tr>
+            <tr>
+                <td>Version to (major)</td>
+                <td> @currentVersion.VersionTo.Major</td>
+            </tr>
+        }
+        else
+        {
+            <tr>
+                <td colspan="2">currentVersion is null</td>
+            </tr>
+        }
+        <tr>
+            <td>Current version in web.config</td>
+            <td>@currentUmbracoVersion</td>
+        </tr>
+        <tr>
+            <td>Is this documentation removed for v8?</td>
+            <td>@currentVersionIsRemovedForv8</td>
+        </tr>
+    </table>
+}
+
+@if (currentUmbracoVersion == 8
+     && currentVersionIsRemovedForv8 == false 
+     && currentVersion != null
+     && currentVersion.Url.EndsWith("-v7") == false
+     && currentVersion.VersionFrom.Major == 7 
+     && currentVersion.VersionTo.Major == 0)
+{
+    <div class="note">
+        <p><strong>This article has not yet been verified against Umbraco 8.</strong></p>
+        <p>
+            The concepts and code examples might not work if you are running Umbraco 8.0 or a later version.
+            If you are using Umbraco 7, this article is perfect for you!
+        </p>
+        <p>You are more than welcome to report any issues found on the <a href="https://github.com/umbraco/UmbracoDocs/issues">Documentation Issue Tracker</a>.</p>
+    </div>
+}
+
+@if (currentUmbracoVersion == 8 
+     && currentVersion != null
+     && currentVersion.Url.EndsWith("-v7") == false
+     && currentVersionIsRemovedForv8)
+{
+    <div class="warning">
+        <p><strong>This article does not apply to Umbraco 8.</strong></p>
+        <p>
+            The concepts and code in this article have been deprecated in Umbraco 8 and no longer apply.<br />
+            If you are using Umbraco 7, this article is perfect for you!
+        </p>
+    </div>
+}
+
 @Html.Raw(markdown)
+

--- a/OurUmbraco.Site/config/ExamineIndex.config
+++ b/OurUmbraco.Site/config/ExamineIndex.config
@@ -71,6 +71,7 @@ More information and documentation can be found on CodePlex: http://umbracoexami
             <add Name="keywords" />
             <add Name="versionFrom" />
             <add Name="versionTo" />
+            <add Name="versionRemoved" />
             <add Name="majorVersion" />
             <add Name="assetID" />
             <add Name="product" />

--- a/OurUmbraco/Our/Examine/ExamineHelper.YamlMetaData.cs
+++ b/OurUmbraco/Our/Examine/ExamineHelper.YamlMetaData.cs
@@ -33,6 +33,7 @@ namespace OurUmbraco.Our.Examine
             /// A space separated list of Topic IDs
             /// </summary>
             public string Topics { get; set; }
+            public string VersionRemoved { get; internal set; }
         }
     }
 }

--- a/OurUmbraco/Our/Examine/ExamineHelper.cs
+++ b/OurUmbraco/Our/Examine/ExamineHelper.cs
@@ -152,6 +152,7 @@ namespace OurUmbraco.Our.Examine
                 simpleDataSet.RowData.Add("complexity", yamlMetaData.Complexity);
                 simpleDataSet.RowData.Add("meta.Title", yamlMetaData.MetaTitle);
                 simpleDataSet.RowData.Add("meta.Description", yamlMetaData.MetaDescription);
+                simpleDataSet.RowData.Add("versionRemoved", yamlMetaData.VersionRemoved);
 
                 var matchingMajorVersions = CalculateMajorVersions(yamlMetaData);
                 simpleDataSet.RowData.Add("majorVersion", string.Join(" ", matchingMajorVersions));
@@ -171,6 +172,8 @@ namespace OurUmbraco.Our.Examine
             var semverCurrent = new Semver.SemVersion(currentDocVersion);
             bool hasFrom = Semver.SemVersion.TryParse(yamlMetaData.VersionFrom, out Semver.SemVersion semverFrom);
             bool hasTo = Semver.SemVersion.TryParse(yamlMetaData.VersionTo, out Semver.SemVersion semverTo);
+            bool hasRemoved = Semver.SemVersion.TryParse(yamlMetaData.VersionRemoved, out Semver.SemVersion semverRemoved);
+
 
             if (hasFrom == false) { semverFrom = new Semver.SemVersion(currentDocVersion); }
             if (hasTo == false) { semverTo = semverFrom < semverCurrent ? semverCurrent : semverFrom; }
@@ -179,8 +182,15 @@ namespace OurUmbraco.Our.Examine
             var matchingMajorVersions = new List<int>();
             for (int i = semverFrom.Major; i <= semverTo.Major; i++)
             {
-                yield return i;
+                matchingMajorVersions.Add(i);
             }
+
+            if (hasRemoved)
+            {
+                matchingMajorVersions.RemoveAll(x => x == semverRemoved.Major);
+            }
+
+            return matchingMajorVersions;
         }
 
         private static int GetCurrentDocVersion()

--- a/OurUmbraco/Our/Examine/OurSearcher.cs
+++ b/OurUmbraco/Our/Examine/OurSearcher.cs
@@ -73,11 +73,11 @@ namespace OurUmbraco.Our.Examine
                 ? ConfigurationManager.AppSettings[Constants.AppSettings.DocumentationCurrentMajorVersion]
                 : MajorDocsVersion.ToString();
 
-            //we filter by this version by excluding the other major versions in lucene so
-            var versionsToNegate = currentMajorVersions.Where(f => f != versionToFilterBy).ToArray<string>();
-            foreach (var versionToNegate in versionsToNegate)
+            //we filter by this version by using the major versions
+            var versionToFind = currentMajorVersions.Where(f => f == versionToFilterBy).ToArray<string>();
+            foreach (var versionToNegate in versionToFind)
             {
-                sb.AppendFormat("-majorVersion:{0} ", versionToNegate);
+                sb.AppendFormat("+majorVersion:{0} ", versionToNegate);
             }
             
             if (!string.IsNullOrEmpty(Term))

--- a/OurUmbraco/Repository/Models/DocumentationVersion.cs
+++ b/OurUmbraco/Repository/Models/DocumentationVersion.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Semver;
+﻿using Semver;
 
 namespace OurUmbraco.Repository.Models
 {
@@ -16,6 +11,7 @@ namespace OurUmbraco.Repository.Models
         public bool IsCurrentPage { get; internal set; }
         public SemVersion VersionFrom { get; internal set; }
         public SemVersion VersionTo { get; internal set; }
+        public string VersionRemoved { get; internal set; }
         public string MetaTitle { get; set; }
         public string MetaDescription { get; set; }
     }

--- a/OurUmbraco/Repository/Services/DocumentationVersionService.cs
+++ b/OurUmbraco/Repository/Services/DocumentationVersionService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,11 @@ namespace OurUmbraco.Repository.Services
 {
     public class DocumentationVersionService
     {
+
+        public string GetCurrentMajorVersion()
+        {
+            return ConfigurationManager.AppSettings[Constants.AppSettings.DocumentationCurrentMajorVersion];
+        }
 
         public IEnumerable<DocumentationVersion> GetAlternateDocumentationVersions(Uri uri, bool allVersions = false)
         {

--- a/OurUmbraco/Repository/Services/DocumentationVersionService.cs
+++ b/OurUmbraco/Repository/Services/DocumentationVersionService.cs
@@ -73,6 +73,7 @@ namespace OurUmbraco.Repository.Services
                         Version = CalculateVersionInfo(f["versionFrom"], f["versionTo"]),
                         VersionFrom = string.IsNullOrWhiteSpace( f["versionFrom"] ) ?  new Semver.SemVersion(0) : Semver.SemVersion.Parse(f["versionFrom"]),
                         VersionTo = string.IsNullOrWhiteSpace(f["versionTo"]) ? new Semver.SemVersion(0) : Semver.SemVersion.Parse(f["versionTo"]),
+                        VersionRemoved = f["versionRemoved"],
                         IsCurrentVersion = f["url"].ToLowerInvariant() == currentUrl.ToLowerInvariant(),
                         IsCurrentPage = f["url"].ToLowerInvariant() == currentPageUrl,
                         MetaDescription = f["meta.Description"],


### PR DESCRIPTION
Because all files have now a versionFrom (when https://github.com/umbraco/UmbracoDocs/pull/1574 is merged) we can turn the logic around to make sure that the file can be found a cross multiple versions.

To test: 
Search for Tours (v7) will return content.  Currently "Tours" with v8 won't return content.
If this PR (and the docs PR) is merged, the v8 will return the same content as v7 as there is no difference in the documentation for the "tours" section.  If you search for v6, there should be no results.