### PR TITLE
Prepare major version switch for docs

### DIFF
--- a/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
+++ b/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
@@ -2,14 +2,14 @@
 @using OurUmbraco.Repository.Services
 @{
     Layout = "~/Views/Master.cshtml";
+
+    var docVersionService = new DocumentationVersionService();
+    var currentVersion = docVersionService.GetCurrentMajorVersion();
+    var altVersions = docVersionService.GetAlternateDocumentationVersions(Request.Url, true);
+
+    var currentDocVersion = altVersions.Where(x => x.IsCurrentPage).FirstOrDefault();
 }
 @section SeoMetaData {
-    @{
-        var docVersionService = new DocumentationVersionService();
-        var altVersions = docVersionService.GetAlternateDocumentationVersions(Request.Url, true);
-
-        var currentDocVersion = altVersions.Where(x => x.IsCurrentPage).FirstOrDefault();
-    }
     @if (currentDocVersion != null)
     {
         if (currentDocVersion.MetaTitle != null)
@@ -98,9 +98,9 @@
                                 <label for="search">Search for documentation</label>
                             </div>
                             <select class="version-search-select">
-                                <option value="8">v8</option>
-                                <option value="7" selected="selected">v7</option>
-                                <option value="6">v6</option>
+                                <option value="8" selected="@(currentVersion == "8"? "selected" : null)">v8</option>
+                                <option value="7" selected="@(currentVersion == "7"? "selected" : null)">v7</option>
+                                <option value="6" selected="@(currentVersion == "6"? "selected" : null)">v6</option>    
                             </select>
                         </div>
 

--- a/OurUmbraco.Site/web.template.config
+++ b/OurUmbraco.Site/web.template.config
@@ -148,7 +148,7 @@
         <add key="GitHubClientSecret" value="it's a secret.. and no, this is not the secret, this key will transformed on the build server" />
 		
         <!-- Documentation -->
-        <add key="Documentation:CurrentMajorVersion" value="7" />
+        <add key="Documentation:CurrentMajorVersion" value="8" />
         
         <!-- Upcoming features -->
         <add key="UnhideUpcomingFeatures" value="false"/>

--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -146,7 +146,7 @@
         <add key="GitHubClientSecret" value="#{GitHubClientSecret}#" />
 		
         <!-- Documentation -->
-        <add key="Documentation:CurrentMajorVersion" value="7" />
+        <add key="Documentation:CurrentMajorVersion" value="8" />
 
         <!-- Upcoming features -->
         <add key="UnhideUpcomingFeatures" value="false"/>

--- a/OurUmbraco/Repository/Services/DocumentationVersionService.cs
+++ b/OurUmbraco/Repository/Services/DocumentationVersionService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,10 @@ namespace OurUmbraco.Repository.Services
 {
     public class DocumentationVersionService
     {
+        public string GetCurrentMajorVersion()
+        {
+            return ConfigurationManager.AppSettings[Constants.AppSettings.DocumentationCurrentMajorVersion];
+        }
 
         public IEnumerable<DocumentationVersion> GetAlternateDocumentationVersions(Uri uri, bool allVersions = false)
         {


### PR DESCRIPTION
What needs to be updated when v8 will be launched to switch the docs to a new major