### PR TITLE
Fixed RSS date parsing

### DIFF
--- a/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
+++ b/OurUmbraco/Community/BlogPosts/BlogPostsService.cs
@@ -215,7 +215,7 @@ namespace OurUmbraco.Community.BlogPosts
             DateTimeOffset pubDate;
             try
             {
-                pubDate = Skybrud.Essentials.Time.TimeUtils.Rfc822ToDateTimeOffset(publishDate);
+                return Skybrud.Essentials.Time.TimeUtils.Rfc822ToDateTimeOffset(publishDate);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
As reported in #406, the date parsing in RSS feeds didn't quite work as expected.

My `TimeUtils.Rfc822ToDateTimeOffset` method used for the parsing actually does what it should, but the returned value was never used as it was immediately overwritten by `DateTimeOffset.TryParse`.