### PR TITLE
Make removing the v8 warning note possible

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
@@ -157,10 +157,7 @@
 
 @if (currentUmbracoVersion == 8
      && currentVersionIsRemovedForv8 == false 
-     && currentVersion != null
-     && currentVersion.Url.EndsWith("-v7") == false
-     && currentVersion.VersionFrom.Major == 7 
-     && currentVersion.VersionTo.Major == 0)
+     && currentVersion.NeedsV8Update == "true")
 {
     <div class="note">
         <p><strong>This article has not yet been verified against Umbraco 8.</strong></p>

--- a/OurUmbraco.Site/config/ExamineIndex.config
+++ b/OurUmbraco.Site/config/ExamineIndex.config
@@ -80,6 +80,7 @@ More information and documentation can be found on CodePlex: http://umbracoexami
             <add Name="audience" />
             <add Name="meta.Title" />
             <add Name="meta.Description" />
+            <add Name="needsV8Update" />
         </IndexUserFields>
     </IndexSet>
 

--- a/OurUmbraco/Our/Examine/ExamineHelper.YamlMetaData.cs
+++ b/OurUmbraco/Our/Examine/ExamineHelper.YamlMetaData.cs
@@ -34,6 +34,7 @@ namespace OurUmbraco.Our.Examine
             /// </summary>
             public string Topics { get; set; }
             public string VersionRemoved { get; internal set; }
+            public string NeedsV8Update { get; set; }
         }
     }
 }

--- a/OurUmbraco/Our/Examine/ExamineHelper.cs
+++ b/OurUmbraco/Our/Examine/ExamineHelper.cs
@@ -153,6 +153,7 @@ namespace OurUmbraco.Our.Examine
                 simpleDataSet.RowData.Add("meta.Title", yamlMetaData.MetaTitle);
                 simpleDataSet.RowData.Add("meta.Description", yamlMetaData.MetaDescription);
                 simpleDataSet.RowData.Add("versionRemoved", yamlMetaData.VersionRemoved);
+                simpleDataSet.RowData.Add("needsV8Update", yamlMetaData.NeedsV8Update);
 
                 var matchingMajorVersions = CalculateMajorVersions(yamlMetaData);
                 simpleDataSet.RowData.Add("majorVersion", string.Join(" ", matchingMajorVersions));

--- a/OurUmbraco/Repository/Models/DocumentationVersion.cs
+++ b/OurUmbraco/Repository/Models/DocumentationVersion.cs
@@ -14,5 +14,6 @@ namespace OurUmbraco.Repository.Models
         public string VersionRemoved { get; internal set; }
         public string MetaTitle { get; set; }
         public string MetaDescription { get; set; }
+        public string NeedsV8Update { get; set; }
     }
 }

--- a/OurUmbraco/Repository/Services/DocumentationVersionService.cs
+++ b/OurUmbraco/Repository/Services/DocumentationVersionService.cs
@@ -77,7 +77,8 @@ namespace OurUmbraco.Repository.Services
                         IsCurrentVersion = f["url"].ToLowerInvariant() == currentUrl.ToLowerInvariant(),
                         IsCurrentPage = f["url"].ToLowerInvariant() == currentPageUrl,
                         MetaDescription = f["meta.Description"],
-                        MetaTitle = f["meta.Title"]
+                        MetaTitle = f["meta.Title"],
+                        NeedsV8Update = f["needsV8Update"]
                     })
                     .OrderByDescending(v=> v.VersionFrom)
                     .ThenBy(v=>v.VersionTo);


### PR DESCRIPTION
# Why?

It is currently not possible for the Docs Curators to remove the note at the top warning people that the article hasn't been tested for v8. We had a discussion at our last meeting and would like to set a YAML tag on all the sections where it makes sense, then those can show the note - it would work as a sort of reminder of what is still in need of an update / check.

# How?

Have added functionality where a YAML tag can be set and then it will only show the note if that is not set. To enable the note we would simply set `needsV8Update: "true"`. We will shortly be rolling out a Docs PR that will add this tag to all articles that currently has the note 🙂 Which is why this is currently a draft PR.