### PR TITLE
Changed "UserName" to read "Email address". Also fixed a typo "cless" to "class"

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Members/ForgotPassword.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/ForgotPassword.cshtml
@@ -16,7 +16,7 @@
         
             <fieldset>
                 <p>
-                    @Html.LabelFor(m => m.Username, new { @cless = "inputLabel" })<br />
+                    @Html.Label("Email address", new { @class = "inputLabel", @for= "Username" })<br />
                     @Html.ValidationMessageFor(m => m.Username)
 
                     @Html.TextBoxFor(m => m.Username, new { @class = "email title" })

--- a/OurUmbraco.Site/Views/Partials/Members/Login.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/Login.cshtml
@@ -13,7 +13,7 @@
 
         <fieldset>
             <p>
-                @Html.LabelFor(m => m.Username, new { @class = "inputLabel" })<br />
+                @Html.Label("Email address", new { @class = "inputLabel", @for = "Username" })<br />
                 @Html.ValidationMessageFor(m => m.Username)
 
                 @Html.TextBoxFor(m => m.Username, new { @class = "email title" })

--- a/OurUmbraco.Site/Views/Partials/Members/ResetPassword.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/ResetPassword.cshtml
@@ -19,7 +19,7 @@
 
                 <fieldset>
                     <p>
-                        @Html.LabelFor(m => m.NewPassword, new { @cless = "inputLabel" })<br />
+                        @Html.LabelFor(m => m.NewPassword, new { @class = "inputLabel" })<br />
                         @Html.ValidationMessageFor(m => m.NewPassword)
 
                         @Html.PasswordFor(m => m.NewPassword, new { @class = "title" })


### PR DESCRIPTION
This PR fixes issue #404
There was also a typo "cless" by the input label on forgot password and reset password forms which I have fixed. Also in addition to the forgot password page I have renamed "Username" to "Email address" as the field label on login page to ensure consistency