### PR TITLE
Revert color change to the note for documentation

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_docs.scss
+++ b/OurUmbraco.Client/src/scss/sections/_docs.scss
@@ -107,7 +107,7 @@
 
 #markdown-docs {
     .note {
-        @include notice(rgba($color-our,.07), rgba($color-our,.70), "\e0d1  Note:");
+        @include notice(rgba(163,219,120,.07), rgba(163,219,120,.70), "\e0d1  Note:");
     }
 
     .warning {


### PR DESCRIPTION
As part of the new Umbraco identity on Our the green note was changed to blue. We already have a blue tip though, I think in this instance it should stay the old color to differentiate 🙂