### PR TITLE
Add v7.14 option to version.config

### DIFF
--- a/OurUmbraco.Site/config/uVersion.config
+++ b/OurUmbraco.Site/config/uVersion.config
@@ -10,12 +10,13 @@
   <versions>
     <!-- version key="v5" name="Version 5.0.x" description="Compatible with version 5.0.x" vote="false"/ -->
     <version key="v800" name="Version 8.0.x" description="Compatible with version 8.0.x" vote="true" voteDescription="Version 8.0.x" voteName="8.0.x"/>
+    <version key="v7140" name="Version 7.14.x" description="Compatible with version 7.14.x" vote="true" voteDescription="Version 7.14.x" voteName="7.14.x"/>
     <version key="v7130" name="Version 7.13.x" description="Compatible with version 7.13.x" vote="true" voteDescription="Version 7.13.x" voteName="7.13.x"/>
     <version key="v7120" name="Version 7.12.x" description="Compatible with version 7.12.x" vote="true" voteDescription="Version 7.12.x" voteName="7.12.x"/>
     <version key="v7110" name="Version 7.11.x" description="Compatible with version 7.11.x" vote="true" voteDescription="Version 7.11.x" voteName="7.11.x"/>
     <version key="v7100" name="Version 7.10.x" description="Compatible with version 7.10.x" vote="true" voteDescription="Version 7.10.x" voteName="7.10.x"/>
     <version key="v790" name="Version 7.9.x" description="Compatible with version 7.9.x" vote="true" voteDescription="Version 7.9.x" voteName="7.9.x"/>
-	<version key="v780" name="Version 7.8.x" description="Compatible with version 7.8.x" vote="true" voteDescription="Version 7.8.x" voteName="7.8.x"/>
+    <version key="v780" name="Version 7.8.x" description="Compatible with version 7.8.x" vote="true" voteDescription="Version 7.8.x" voteName="7.8.x"/>
     <version key="v770" name="Version 7.7.x" description="Compatible with version 7.7.x" vote="true" voteDescription="Version 7.7.x" voteName="7.7.x"/>
     <version key="v760" name="Version 7.6.x" description="Compatible with version 7.6.x" vote="true" voteDescription="Version 7.6.x" voteName="7.6.x"/>
     <version key="v750" name="Version 7.5.x" description="Compatible with version 7.5.x" vote="true" voteDescription="Version 7.5.x" voteName="7.5.x"/>


### PR DESCRIPTION
Umbraco 7.14 was released a couple of weeks ago but currently doesn't show up on the list of available versions for packages... I have updated it here!