### PR TITLE
Remove breamdcrumb for versioned files

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Documentation/Breadcrumb.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Documentation/Breadcrumb.cshtml
@@ -27,11 +27,15 @@
                 baseurl += page + "/";
             }
         }
-
-        @if (!absolutePath.EndsWith("/"))
+        
+        @if (!absolutePath.Contains("-v"))
         {
-            <li>@absolutePath.Substring(absolutePath.LastIndexOf('/') + 1).RemoveDash().UnderscoreToDot().EnsureCorrectDocumentationText()</li>
+            if (!absolutePath.EndsWith("/"))
+            {
+                <li>@absolutePath.Substring(absolutePath.LastIndexOf('/') + 1).RemoveDash().UnderscoreToDot().EnsureCorrectDocumentationText()</li>
+            }
         }
+
 
 
 


### PR DESCRIPTION
Currently the index filename is included in the breadcrumbs for versioned files, this PR will remove that.

Current state:
![Capture](https://user-images.githubusercontent.com/36075913/55150163-e3566d80-514b-11e9-8e2d-8d411dc78233.PNG)

After this fix:
![Capture](https://user-images.githubusercontent.com/36075913/55150216-fa955b00-514b-11e9-9ee4-8da31fa0b49e.PNG)


