### PR TITLE
Fix broken link after renaming branches in the CMS

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
@@ -5,7 +5,7 @@
     <li class="@(page.IsAncestorOrSelf(Model.Content) ? "current" : null)">
         @if (page.Name == "Contribute")
         {
-            <a href="https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/.github/CONTRIBUTING.md" target="_blank">@page.Name</a>
+            <a href="https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/.github/CONTRIBUTING.md" target="_blank">@page.Name</a>
         }
         else
         {


### PR DESCRIPTION
The contribute navigation button didn't work as it has the branch name in the link, and the branches were recently restructured with different names.

Claus has fixed it directly on the live site, but this will need to be merged in for the next deployment so we don't overwrite his change with the error again 🙂