### PR TITLE
enclose most of web.config sections to set inheritInChildApplications…

### DIFF
--- a/OurUmbraco.Site/web.template.config
+++ b/OurUmbraco.Site/web.template.config
@@ -24,6 +24,8 @@
         </sectionGroup>
     </configSections>
 
+  <location path="." inheritInChildApplications="false">
+
     <umbracoConfiguration>
         <settings configSource="config\umbracoSettings.config" />
         <BaseRestExtensions configSource="config\BaseRestExtensions.config" />
@@ -681,6 +683,7 @@
         </rewrite>
         <validation validateIntegratedModeConfiguration="false" />
     </system.webServer>
+  </location>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>

--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -24,6 +24,8 @@
         </sectionGroup>
     </configSections>
 
+  <location path="." inheritInChildApplications="false">
+
     <umbracoConfiguration>
         <settings configSource="config\umbracoSettings.config" />
         <BaseRestExtensions configSource="config\BaseRestExtensions.config" />
@@ -675,6 +677,7 @@
         </rewrite>
         <validation validateIntegratedModeConfiguration="false" />
     </system.webServer>
+  </location>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>


### PR DESCRIPTION
… to false

Needed so that Our can have a child application running in its own application pool (for docfx version of documentation)