### PR TITLE
Fixed mobile navigation issues on the front page (maybe)

### DIFF
--- a/OurUmbraco.Client/src/js/app.js
+++ b/OurUmbraco.Client/src/js/app.js
@@ -22,7 +22,7 @@ jQuery(document).ready(function () {
     });
 
     // Mobile navigation
-    $("#toggle").click(function (e) {
+    $("#toggle a").click(function (e) {
         e.preventDefault();
         $(".cross").toggleClass("open");
         $("nav").toggleClass("open");


### PR DESCRIPTION
As reported by in #439, the mobile navigation is broken on the live site. I can't however reproduce this locally with the newest code, but inspecting the code on the live site, it appears to be the same.

I played a bit around in the console of the browser on the live site, and placing the click event on the `a` instead of the `div` seems to fix this. But I can tell for sure as I can't reproduce it locally.

