### PR TITLE
Twitter: Removed call to get authenticated user

### DIFF
--- a/OurUmbraco/Community/Twitter/TwitterService.cs
+++ b/OurUmbraco/Community/Twitter/TwitterService.cs
@@ -36,8 +36,6 @@ namespace OurUmbraco.Community.Twitter
                                     ConfigurationManager.AppSettings["twitterUserAccessToken"],
                                     ConfigurationManager.AppSettings["twitterUserAccessSecret"]);
 
-                            Tweetinvi.User.GetAuthenticatedUser();
-
                             var searchParameter = new SearchTweetsParameters("umbraco")
                             {
                                 SearchType = SearchResultType.Recent


### PR DESCRIPTION
Twitter has made some breaking changes, meaning that some JSON properties in the user object that used to be returned by their API are no longer there. This breaks Tweetinvi, and apparently the developer wont be able to release an update to address this for some months.

Our's current implementation of the Twitter feed makes a request to get information about the authenticated Twitter user. As Tweetinvi are no longer able to parse the response, the feed fails.

The solution is therefore just to remove the line, as apparently isn't used for anything. I tried to remove the line in my local setup, and the feed now works again.