### PR TITLE
- fixed the issue with the headline showing as most popular packages

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -13,7 +13,16 @@
     var version = Request["version"];
     var term = Request["term"];
     var pageSize = 20;
-    var headline = orderMode == "updateDate" ? "latest" : "most popular";
+    var headline = "most popular";
+    if (orderMode == "createDate")
+    {
+        headline = "latest";
+    }
+    else if (orderMode == "updateDate")
+    {
+        headline = "recently updated";
+    }
+
     if (version != null)
     {
         headline = "version " + version;


### PR DESCRIPTION
- fixed the issue with the headline showing as most popular packages by default when we are actually seeing latest packages.

So now it depending on the order mode it will show as 'latest', 'recently updated' or 'most popular'.

This fixes issue #449 