### PR TITLE
Potential fix for issue #461: Update DocumentationContentFinder.cs

### DIFF
--- a/OurUmbraco/Documentation/DocumentationContentFinder.cs
+++ b/OurUmbraco/Documentation/DocumentationContentFinder.cs
@@ -62,7 +62,7 @@ namespace OurUmbraco.Documentation
             // set the context vars
             var httpContext = contentRequest.RoutingContext.UmbracoContext.HttpContext;
             httpContext.Items[MarkdownLogic.MarkdownPathKey] = mdFilepath;
-            httpContext.Items["topicTitle"] = string.Join(" - ", httpContext.Request.RawUrl
+            httpContext.Items["topicTitle"] = string.Join(" - ", httpContext.Request.Url.AbsolutePath
                 .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
                 .Skip(1)
                 .Reverse());


### PR DESCRIPTION
The code that sets "topicTitle" uses Request.RawUrl as a base for splitting the current page "path", reversing it and displaying it in <title />. Not sure if that's the best approach all round, but RawUrl includes the querystring which I'm sure sucks.

I've given up trying to run the website locally (everything and HTTPS seems to screw me over for more than an hour now) so this is **_untested_** (!!!), but I'm hoping someone (hi @nul800sebastiaan ;-) ) with a working local setup might be able to do a quick test to see if this oneliner fixes https://github.com/umbraco/OurUmbraco/issues/461 ? Pretty please?