### PR TITLE
Home page - Open meetups and Twitter Activity in a new window

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Home/Meetups.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Home/Meetups.cshtml
@@ -33,7 +33,7 @@
         }
     }
 
-    <a href="@item.Event.Link" class="forum-thread">
+    <a href="@item.Event.Link" class="forum-thread" target="_blank">
         @if (item.Group.GroupPhoto != null)
         {
             <div class="avatar">

--- a/OurUmbraco.Site/Views/Partials/Home/TwitterSearchUmbraco.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Home/TwitterSearchUmbraco.cshtml
@@ -11,7 +11,7 @@
 {
     foreach (var tweet in Model.Tweets)
     {
-        <a href="https://twitter.com/@tweet.Author.ScreenName/status/@tweet.Id" class="forum-thread">
+        <a href="https://twitter.com/@tweet.Author.ScreenName/status/@tweet.Id" class="forum-thread" target="_blank">
 
             <div class="avatar">
                 <img src="@tweet.Author.ProfileImageUrl.Replace("http://", "https://")" />


### PR DESCRIPTION
This PR fixes issue [464](https://github.com/umbraco/OurUmbraco/issues/464).

On the home page of the site the meetup links and twitter activity links open in the same window. This PR addresses this issue.

Regards,
Poornima