### PR TITLE
Fix 'view my public profile' link in the quick menu

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Members/QuickMenu.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Members/QuickMenu.cshtml
@@ -64,7 +64,7 @@
                             </span>
                         }
                         <div class="public-profile">
-                            <a href="@Url.GetProfileUrl(profile)">View my public profile</a>
+                            <a href="/member/@profile.Id">View my public profile</a>
                         </div>
                         @if (profile.IsAdmin)
                         {


### PR DESCRIPTION
This PR fixes the issue #469 'View my public profile' link which occurs when the member has linked their GitHub account to their our account.

![Quick menu view my public profile link](https://i.imgur.com/7LEdwXc.png)

![Page not found](https://imgur.com/T5zo8BH.png)

This fix uses the same link that is used when you click on someone's name in a comment on the forum.

![Forum comment name url](https://imgur.com/lCWDgHd.png)

It then goes to the correct page for the member

![Correct public profile url](https://imgur.com/FG6SRYa.png)