### PR TITLE
Updated Google Analytics script to load library

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ProjectDetails.cshtml
@@ -475,6 +475,10 @@
     if (Model.Content.HasValue("gaCode"))
     {
         <script type="text/javascript">
+             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
              ga('create', '@(Model.Content.GetPropertyValue("gaCode"))', 'auto', { 'name': 'PackageMaker' });
              ga('PackageMaker.send', 'pageview');
         </script>


### PR DESCRIPTION
The analytics.js script was no longer loaded on Our after a switch was made from analytics.js to Google Tag Manager. For the UA code of Package owners to properly trigger, the above code is needed.