### PR TITLE
Fix search box width

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_search-big.scss
+++ b/OurUmbraco.Client/src/scss/elements/_search-big.scss
@@ -9,7 +9,7 @@
     }
 
     div.textSearch {
-        width: 80%;
+        width: 100%;
     }
 
     input {


### PR DESCRIPTION
This pr changes the width of the docs search box to fill the entire horizontal space.

Before the change there was an empty gap after the version dropdown:
<img width="1410" alt="Screen Shot 2019-10-09 at 7 44 46 PM" src="https://user-images.githubusercontent.com/2272928/66530477-8e69bb80-eacd-11e9-8ed6-9c0bb856e84e.png">

After the change:
<img width="1410" alt="Screen Shot 2019-10-09 at 7 44 35 PM" src="https://user-images.githubusercontent.com/2272928/66530485-94f83300-eacd-11e9-8b31-e633162d8e47.png">

Tested on (latest stable version of each browser):
Chrome 77
Firefox 69
Safari 13
IE 11