### PR TITLE
updating repos list on page

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -157,7 +157,7 @@ else
                                 <a href="https://github.com/umbraco/Umbraco.Courier.Contrib" target="_blank" rel="noreferrer noopener" title="Umbraco.Courier.Contrib">Umbraco.Courier.Contrib</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.ValueConnectors" target="_blank" rel="noreferrer noopener" title="Umbraco.Deploy.ValueConnectors">Umbraco.Deploy.ValueConnectors</a>,
                                 <a href="https://github.com/umbraco/rfcs" target="_blank rel="noreferrer noopener" title="RFCs">RFCs</a>,
-                                <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank rel="noreferrer noopener" title="The-Starter-Kit">The Starter Kit</a> and
+                                <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank rel="noreferrer noopener" title="The-Starter-Kit">The-Starter-Kit</a> and
                                 <a href="https://github.com/umbraco/organizer-guide" target="_blank rel="noreferrer noopener" title="organizer-guide">organizer-guide</a> repos
                             </small>
                         </p>

--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -150,15 +150,15 @@ else
                         <p>
                             <small class="github-repo-list">
                                 Contributions to default branches for
-                                <a href="https://github.com/umbraco/Umbraco-CMS" target="_blank rel="noreferrer noopener" title="Umbraco-CMS">Umbraco-CMS</a>,
+                                <a href="https://github.com/umbraco/Umbraco-CMS" target="_blank" rel="noreferrer noopener" title="Umbraco-CMS">Umbraco-CMS</a>,
                                 <a href="https://github.com/umbraco/UmbracoDocs" target="_blank" rel="noreferrer noopener" title="UmbracoDocs">UmbracoDocs</a>,
                                 <a href="https://github.com/umbraco/OurUmbraco" target="_blank" rel="noreferrer noopener" title="OurUmbraco">OurUmbraco</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.Contrib" target="_blank"`rel="noreferrer noopener" title="Umbraco.Deploy.Contrib">Umbraco.Deploy.Contrib</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Courier.Contrib" target="_blank" rel="noreferrer noopener" title="Umbraco.Courier.Contrib">Umbraco.Courier.Contrib</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.ValueConnectors" target="_blank" rel="noreferrer noopener" title="Umbraco.Deploy.ValueConnectors">Umbraco.Deploy.ValueConnectors</a>,
-                                <a href="https://github.com/umbraco/rfcs" target="_blank rel="noreferrer noopener" title="RFCs">RFCs</a>,
-                                <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank rel="noreferrer noopener" title="The-Starter-Kit">The-Starter-Kit</a> and
-                                <a href="https://github.com/umbraco/organizer-guide" target="_blank rel="noreferrer noopener" title="organizer-guide">organizer-guide</a> repos
+                                <a href="https://github.com/umbraco/rfcs" target="_blank" rel="noreferrer noopener" title="RFCs">RFCs</a>,
+                                <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank" rel="noreferrer noopener" title="The-Starter-Kit">The-Starter-Kit</a> and
+                                <a href="https://github.com/umbraco/organizer-guide" target="_blank" rel="noreferrer noopener" title="organizer-guide">organizer-guide</a> repos
                             </small>
                         </p>
                     </div>

--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -154,8 +154,11 @@ else
                                 <a href="https://github.com/umbraco/UmbracoDocs" target="_blank" rel="noreferrer noopener" title="UmbracoDocs">UmbracoDocs</a>,
                                 <a href="https://github.com/umbraco/OurUmbraco" target="_blank" rel="noreferrer noopener" title="OurUmbraco">OurUmbraco</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.Contrib" target="_blank"`rel="noreferrer noopener" title="Umbraco.Deploy.Contrib">Umbraco.Deploy.Contrib</a>,
-                                <a href="https://github.com/umbraco/Umbraco.Courier.Contrib" target="_blank" rel="noreferrer noopener" title="Umbraco.Courier.Contrib">Umbraco.Courier.Contrib</a> and
-                                <a href="https://github.com/umbraco/Umbraco.Deploy.ValueConnectors" target="_blank" rel="noreferrer noopener" title="Umbraco.Deploy.ValueConnectors">Umbraco.Deploy.ValueConnectors</a> repos
+                                <a href="https://github.com/umbraco/Umbraco.Courier.Contrib" target="_blank" rel="noreferrer noopener" title="Umbraco.Courier.Contrib">Umbraco.Courier.Contrib</a>,
+                                <a href="https://github.com/umbraco/Umbraco.Deploy.ValueConnectors" target="_blank" rel="noreferrer noopener" title="Umbraco.Deploy.ValueConnectors">Umbraco.Deploy.ValueConnectors</a>,
+                                <a href="https://github.com/umbraco/rfcs" target="_blank rel="noreferrer noopener" title="RFCs">RFCs</a>,
+                                <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank rel="noreferrer noopener" title="The-Starter-Kit">The Starter Kit</a> and
+                                <a href="https://github.com/umbraco/organizer-guide" target="_blank rel="noreferrer noopener" title="organizer-guide">organizer-guide</a> repos
                             </small>
                         </p>
                     </div>


### PR DESCRIPTION
Hello,

I realised on PR #482 I had updated the logic but not the list on homepage of which repos are included for contributions, so I have added them now :)

Should look like this:
![image](https://user-images.githubusercontent.com/9353655/66747359-3f7ca700-ee7c-11e9-8430-f8c9fd5f9945.png)


Thanks,
Carole