### PR TITLE
Cleanup release URLs

### DIFF
--- a/OurUmbraco.Site/Views/Download.cshtml
+++ b/OurUmbraco.Site/Views/Download.cshtml
@@ -1,5 +1,6 @@
 ﻿@inherits UmbracoTemplatePage
 @using ClientDependency.Core.Mvc
+@using OurUmbraco.Our.Extensions
 @using OurUmbraco.Our.Services
 @{
     Layout = "~/Views/Master.cshtml";
@@ -35,7 +36,7 @@
                     comes with a powerful deployment setup out of the box, that lets you deploy new iterations of your site with the click
                     of a button. See how it works:
                 </p>
-                
+
                 <div class="video video-element large-margin-bottom">
                     <a href="/documentation/Umbraco-Cloud/Deployment/">
                         <img src="https://our.umbraco.com/documentation/Umbraco-Cloud/Deployment/Cloud-to-Cloud/images/deploy-in-portal.gif" alt="See how Umbraco Cloud works" />
@@ -56,7 +57,7 @@
 
                 <p class="large-margin-bottom">
                     Current Version:
-                    <a id="downloadButton" class="download-link" href="/contribute/releases/@(latestRelease.FullVersion.ToString().Replace(".", string.Empty))?fromdownload=true">Download @(latestRelease.FullVersion)</a>
+                    <a id="downloadButton" class="download-link" href="@Url.GetReleaseUrl(latestRelease, true)">Download @(latestRelease.FullVersion)</a>
                     -  See all <a class="download-link" href="/contribute/releases/">previous releases</a>
                 </p>
 

--- a/OurUmbraco.Site/Views/Partials/Releases/AllReleases.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Releases/AllReleases.cshtml
@@ -1,3 +1,4 @@
+@using OurUmbraco.Our.Extensions
 @using OurUmbraco.Our.Services
 @inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 
@@ -40,7 +41,7 @@
     }
 
     var infoText = string.Join("&nbsp;|&nbsp;", infoTexts);
-    
+
     <div class="row releaseTable">
         <div class="col-xs-3">
 
@@ -65,7 +66,7 @@
 
                 <!-- latest release -->
                 <div class="col-xs-12">
-                    <h4 style="display: inline"><a href="@(Model.Content.Url + "/" + newestReleaseInGroup.Version.Replace(".", string.Empty))">v@(newestReleaseInGroup.Version)</a></h4>
+                    <h4 style="display: inline"><a href="@Url.GetReleaseUrl(newestReleaseInGroup)">v@(newestReleaseInGroup.Version)</a></h4>
                     <p style="display: inline; padding-left: 20px; color: rgba(0, 0, 0, .4); font-size: .8rem;">@Html.Raw(infoText)</p>
                 </div>
 
@@ -73,7 +74,7 @@
                 @foreach (var minorRelease in releasesInGroup.Skip(1))
                 {
                     <div class="col-xs-4" style="min-height: 133px">
-                        <h5><a href="@(Model.Content.Url + "/" + minorRelease.Version.Replace(".", string.Empty))">@minorRelease.Version</a></h5>
+                        <h5><a href="@Url.GetReleaseUrl(minorRelease)">@minorRelease.Version</a></h5>
                     </div>
                 }
             </div>

--- a/OurUmbraco.Site/Views/Release.cshtml
+++ b/OurUmbraco.Site/Views/Release.cshtml
@@ -54,7 +54,7 @@
                             {
 
                                 <li>
-                                    <a class="active" href="/contribute/releases/@(currentRelease.Version.Replace(".", string.Empty))">
+                                    <a class="active" href="@Url.GetReleaseUrl(currentRelease)">
                                         <h3>Latest Release - v@(currentRelease.Version)</h3>
                                     </a>
                                 </li>

--- a/OurUmbraco.Site/Views/ReleaseLanding.cshtml
+++ b/OurUmbraco.Site/Views/ReleaseLanding.cshtml
@@ -1,4 +1,5 @@
-﻿@using OurUmbraco.Our.Services
+﻿@using OurUmbraco.Our.Extensions
+@using OurUmbraco.Our.Services
 @inherits UmbracoTemplatePage
 @{
     Layout = "~/Views/Master.cshtml";
@@ -17,7 +18,7 @@
                             @foreach (var currentRelease in allReleases.Where(x => x.Released && x.LatestRelease))
                             {
                                 <li>
-                                    <a class="active" href="/contribute/releases/@(currentRelease.Version.Replace(".", string.Empty))">
+                                    <a class="active" href="@Url.GetReleaseUrl(currentRelease)">
                                         <h3>Latest Release - v@(currentRelease.Version)</h3>
                                     </a>
                                 </li>

--- a/OurUmbraco.Site/Views/ReleaseProgress.cshtml
+++ b/OurUmbraco.Site/Views/ReleaseProgress.cshtml
@@ -21,7 +21,7 @@
                             @foreach (var currentRelease in allReleases.Where(x => x.Released && x.LatestRelease))
                             {
                                 <li>
-                                    <a class="active" href="/contribute/releases/@(currentRelease.Version.Replace(".", string.Empty))">
+                                    <a class="active" href="@Url.GetReleaseUrl(currentRelease)">
                                         <h3>Latest Release - v@(currentRelease.Version)</h3>
                                     </a>
                                 </li>
@@ -34,7 +34,7 @@
                                     @foreach (var release in inProgress)
                                     {
                                         <li>
-                                            <a href="/contribute/releases/@(release.Version.Replace(".", string.Empty))">
+                                            <a href="@Url.GetReleaseUrl(release)">
                                                 <h4>v@(release.Version)</h4>
                                             </a>
                                         </li>
@@ -87,7 +87,7 @@
                                 <div class="col-xs-9">
                                     <div class="row explain">
                                         <div class="col-xs-12">
-                                            <h4 class="text-right"><a href="/contribute/releases/@(release.Version.Replace(".",""))">v@(release.Version)</a></h4>
+                                            <h4 class="text-right"><a href="@Url.GetReleaseUrl(release)">v@(release.Version)</a></h4>
                                         </div>
                                         <div class="col-xs-6">
                                             <div class="changes">

--- a/OurUmbraco/Our/Extensions/UrlExtensions.cs
+++ b/OurUmbraco/Our/Extensions/UrlExtensions.cs
@@ -1,14 +1,11 @@
-﻿
-using System;
+﻿using System;
 using System.Web.Mvc;
 using OurUmbraco.Our.Models;
 
 namespace OurUmbraco.Our.Extensions
 {
-
     public static class UrlExtensions
     {
-
         public static string GetProfileUrl(this UrlHelper helper, MemberData member)
         {
             return "/members/" + (member.HasGitHubUsername ? member.GitHubUsername : "id:" + member.Id) + "/";
@@ -31,6 +28,14 @@ namespace OurUmbraco.Our.Extensions
             return rootUrl + "/members/" + (member.HasGitHubUsername ? member.GitHubUsername : "id:" + member.Id) + "/";
         }
 
-    }
+        public static string GetReleaseUrl(this UrlHelper helper, Release release)
+        {
+            return "/download/releases/" + release.Version.Replace(".", string.Empty);
+        }
 
+        public static string GetReleaseUrl(this UrlHelper helper, Release release, bool download)
+        {
+            return GetReleaseUrl(helper, release) + "?fromdownload=" + download;
+        }
+    }
 }


### PR DESCRIPTION
I went down a bit of a rabbit hole, sorry...

It was really bugging me that the URL for each version on the ["all releases" page](https://our.umbraco.com/download/releases/) contained a double slash...

And then I noticed that some URLs elsewhere on Our point to the old `/contribute/releases/{version}` URL instead, so I decided a centeralised helper would be a nice way to fix this