### PR TITLE
Initialised a GitHub PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!---
+    Thank you for contributing to Umbraco.
+    Fields marked with (*) are required. Please don't remove the template.
+-->
+
+## Description (*)
+<!---
+   Please provide a brief description of this PR.
+-->
+
+## Fixed Issues (if necessary)
+<!---
+    Please mention all the relevant issues this PR fixes.
+-->
+
+## Screenshots (if necessary)
+<!---
+  Provide relevant screenshots for the error fixed or the feature introduced. You can upload JPEGs, PNGs, or GIFs.
+-->
+
+## Contribution checklist (*)
+ - [ ] I have read the Contributing Guidelines
+ - [ ] Commits have been made with meaningful commit messages
+ - [ ] All automated tests have passed successfully 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,22 @@
 <!---
     Thank you for contributing to Umbraco.
-    Fields marked with (*) are required. Please don't remove the template.
+    Fields marked with (*) are required.
 -->
 
 ## Description (*)
 <!---
    Please provide a brief description of this PR.
 -->
-
 ## Fixed Issues (if necessary)
 <!---
     Please mention all the relevant issues this PR fixes.
 -->
-
 ## Screenshots (if necessary)
 <!---
   Provide relevant screenshots for the error fixed or the feature introduced. You can upload JPEGs, PNGs, or GIFs.
 -->
-
 ## Contribution checklist (*)
- - [ ] I have read the Contributing Guidelines
+ - [ ] I have read the [Contributing Guidelines](https://our.umbraco.com/documentation/Contribute/)
  - [ ] Commits have been made with meaningful commit messages
  - [ ] All automated tests have passed successfully 
+


### PR DESCRIPTION
# Description

Now contributors of this repo can send PRs with a standardised description template. Every GitHub repo should have a PR template as it eases the procedure for both contributors and code reviewers.

With this checklist reviewers can make sure how many guidelines have been followed and prioritise their PR reviews as the number of checked items appear on the PR page.

## Preview ⬇️ ⬇️ ⬇️ 
------------------
<!---
    Thank you for contributing to Umbraco.
    Fields marked with (*) are required. Please don't remove the template.
-->

## Description (*)
<!---
   Please provide a brief description of this PR.
-->

## Fixed Issues (if necessary)
<!---
    Please mention all the relevant issues this PR fixes.
-->

## Screenshots (if necessary)
<!---
  Provide relevant screenshots for the error fixed or the feature introduced. You can upload JPEGs, PNGs, or GIFs.
-->

## Contribution checklist (*)
 - [X] I have read the Contributing Guidelines
 - [X] Commits have been made with meaningful commit messages
 - [X] All automated tests have passed successfully 

 