### PR TITLE
Adding the Editor's Manual to Documentation Site

### DIFF
--- a/OurUmbraco/Documentation/DocumentationUpdater.cs
+++ b/OurUmbraco/Documentation/DocumentationUpdater.cs
@@ -196,7 +196,7 @@ namespace OurUmbraco.Documentation
                             return 3;
                         case "starter-kit":
                             return 4;
-                        case "editor-manual":
+                        case "editors-manual":
                             return 5;
 
                         //Add ons

--- a/OurUmbraco/Documentation/DocumentationUpdater.cs
+++ b/OurUmbraco/Documentation/DocumentationUpdater.cs
@@ -132,8 +132,6 @@ namespace OurUmbraco.Documentation
                             return 3;
                         case "code":
                             return 4;
-                        case "manuals":
-                            return 5;
 
                         //Implementation
                         case "default-routing":
@@ -198,6 +196,8 @@ namespace OurUmbraco.Documentation
                             return 3;
                         case "starter-kit":
                             return 4;
+                        case "editor-manual":
+                            return 5;
 
                         //Add ons
                         case "umbracoforms":
@@ -274,10 +274,6 @@ namespace OurUmbraco.Documentation
                             return 1;
                         case "creating-forms":
                             return 2;
-                            
-                        //Getting Started - Manuals
-                        case "editor":
-                            return 0;
 
                         //Implementation - Default Routing
                         case "inbound-pipeline":
@@ -368,6 +364,20 @@ namespace OurUmbraco.Documentation
                             return 8;
                         case "conclusions-where-next":
                             return 9;
+                            
+                        //Tutorials - Editor Manual
+                        case "introduction":
+                            return 0;
+                        case "getting-started-with-umbraco":
+                            return 1;
+                        case "working-with-content":
+                            return 2;
+                        case "version-management":
+                            return 3;
+                        case "media-management":
+                            return 4;
+                        case "tips-and-tricks":
+                            return 5;
 
                         //Add Ons - UmbracoForms
                         case "installation":
@@ -439,24 +449,6 @@ namespace OurUmbraco.Documentation
                         case "courier":
                             return 3;
 
-                    }
-                    break;
-                case 4:
-                    switch (name.ToLowerInvariant())
-                    {
-                        //Getting Started - Manuals - Editor
-                        case "introduction":
-                            return 0;
-                        case "getting-started-with-umbraco":
-                            return 1;
-                        case "working-with-content":
-                            return 2;
-                        case "version-management":
-                            return 3;
-                        case "media-management":
-                            return 4;
-                        case "tips-and-tricks":
-                            return 5;
                     }
                     break;
             }

--- a/OurUmbraco/Documentation/DocumentationUpdater.cs
+++ b/OurUmbraco/Documentation/DocumentationUpdater.cs
@@ -132,6 +132,8 @@ namespace OurUmbraco.Documentation
                             return 3;
                         case "code":
                             return 4;
+                        case "manuals":
+                            return 5;
 
                         //Implementation
                         case "default-routing":
@@ -272,6 +274,10 @@ namespace OurUmbraco.Documentation
                             return 1;
                         case "creating-forms":
                             return 2;
+                            
+                        //Getting Started - Manuals
+                        case "editor":
+                            return 0;
 
                         //Implementation - Default Routing
                         case "inbound-pipeline":
@@ -433,6 +439,24 @@ namespace OurUmbraco.Documentation
                         case "courier":
                             return 3;
 
+                    }
+                    break;
+                case 4:
+                    switch (name.ToLowerInvariant())
+                    {
+                        //Getting Started - Manuals - Editor
+                        case "introduction":
+                            return 0;
+                        case "getting-started-with-umbraco":
+                            return 1;
+                        case "working-with-content":
+                            return 2;
+                        case "version-management":
+                            return 3;
+                        case "media-management":
+                            return 4;
+                        case "tips-and-tricks":
+                            return 5;
                     }
                     break;
             }


### PR DESCRIPTION
May have gotten ahead of myself and adding more levels of navigation than the website can render.

Let me know if this is the case :smile: I'm just happy that I found where this navigation was kept haha.

This alteration is based on a fuller contribution to UmbracoDocs (https://github.com/umbraco/UmbracoDocs/pull/2024).

As I've referenced all the links within the 3rd level navigation we could remove case 4 section if it isn't a quick fix to render - just let me know.
