### PR TITLE
Remove download requirement from voting on compatibility

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/CompatibilityReport.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/CompatibilityReport.cshtml
@@ -97,22 +97,15 @@
     </div>
 
     @if (Model.CurrentMemberIsLoggedIn)
-    {
-        if (Model.CurrentMemberHasDownloaded)
-        {
-            <div id="reportingTools">
-                <a href="#" id="reportCompatibility">Report compatibility</a>
-                <div style="display: none;" id="reportCompatibilityPanel">
-                    <a href="#" id="cancelCompatibility">Cancel</a> or <button>Submit report</button>
-                </div>
-                <br />
+    {        
+        <div id="reportingTools">
+            <a href="#" id="reportCompatibility">Report compatibility</a>
+            <div style="display: none;" id="reportCompatibilityPanel">
+                <a href="#" id="cancelCompatibility">Cancel</a> or <button>Submit report</button>
             </div>
-        }
-        else
-        {
-            <p><small>You need to download this package before you can report on it's compatibility</small></p>
-        }
-    }
+            <br />
+        </div>
+     }
     else
     {
         <p><small>You must login before you can report on package compatibility.</small></p>

--- a/OurUmbraco/Our/Utils.cs
+++ b/OurUmbraco/Our/Utils.cs
@@ -84,13 +84,6 @@ namespace OurUmbraco.Our
             return result ?? 0;
         }
 
-        public static bool HasMemberDownloadedPackage(int memberId, int projectId)
-        {
-            var result = Umbraco.Core.ApplicationContext.Current.DatabaseContext.Database.ExecuteScalar<int>("select COUNT(*) from projectDownload where projectId = @0 and memberId = @1", projectId, memberId);
-            return result != 0;
-        }
-
-
         public static int GetReleaseDownloadCount(int projectId)
         {
             var result = Umbraco.Core.ApplicationContext.Current.DatabaseContext.Database.ExecuteScalar<int?>("SELECT COUNT(*) FROM [projectDownload] WHERE projectId = @0", projectId);

--- a/OurUmbraco/Project/Controllers/ProjectCompatibilityReportController.cs
+++ b/OurUmbraco/Project/Controllers/ProjectCompatibilityReportController.cs
@@ -23,7 +23,6 @@ namespace OurUmbraco.Project.Controllers
                 new VersionCompatibilityReportModel
                 {
                     VersionCompatibilities = compatReport.GetCompatibilityReport(projectId),
-                    CurrentMemberHasDownloaded = currentMember != null && Utils.HasMemberDownloadedPackage(currentMember.Id, projectId),
                     CurrentMemberIsLoggedIn = currentMember != null,
                     FileId = fileId,
                     ProjectId = projectId,


### PR DESCRIPTION
We've had a talk at the London hackathon - it doesn't make sense to require downloading the package before you can report compatibility as it means noone really does it.

Seems the method was only ever used here, so cleaned up the model as well.

https://github.com/umbraco/Umbraco.Packages/issues/20