### PR TITLE
Upgrade to .NET FX 4.8.0

### DIFF
--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -16,7 +16,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OurUmbraco.Site</RootNamespace>
     <AssemblyName>OurUmbraco.Site</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OurUmbraco</RootNamespace>
     <AssemblyName>OurUmbraco</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>


### PR DESCRIPTION
Sets both CSProjs to NET FX 4.8

### Note
Please test this out locally or on a UAT environment to ensure nothing gets messed up. For my local instance I had to do a fresh checkout

## Why
Because the JWT library requires at least 4.7.x and shipping an older library for something that is security related feels a bit wrong

This current WIP/draft PR for adding JWT API tokens for reference https://github.com/umbraco/OurUmbraco/pull/511