### PR TITLE
Allow package voting for 8.3

### DIFF
--- a/OurUmbraco.Site/config/uVersion.config
+++ b/OurUmbraco.Site/config/uVersion.config
@@ -9,6 +9,7 @@
 <configuration default="v750">
   <versions>
     <!-- version key="v5" name="Version 5.0.x" description="Compatible with version 5.0.x" vote="false"/ -->
+    <version key="v830" name="Version 8.3.x" description="Compatible with version 8.3.x" vote="true" voteDescription="Version 8.3.x" voteName="8.3.x"/>
     <version key="v820" name="Version 8.2.x" description="Compatible with version 8.2.x" vote="true" voteDescription="Version 8.2.x" voteName="8.2.x"/>
     <version key="v810" name="Version 8.1.x" description="Compatible with version 8.1.x" vote="true" voteDescription="Version 8.1.x" voteName="8.1.x"/>
     <version key="v800" name="Version 8.0.x" description="Compatible with version 8.0.x" vote="true" voteDescription="Version 8.0.x" voteName="8.0.x"/>


### PR DESCRIPTION
Seems the list of version to report compatibility on for packages is based on this list. Added 8.3 which was released today.