### PR TITLE
Remove Github contribute redirect

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
@@ -1,6 +1,6 @@
 ﻿@inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 <ul>
-    @foreach (var page in Model.Content.AncestorOrSelf(1).Children.Where("Visible"))
+    @foreach (var page in Model.Content.AncestorOrSelf(1).Children.Where(x => x.IsVisible()))
     {
         <li class="@(page.IsAncestorOrSelf(Model.Content) ? "current" : null)">
             @if (page.Name == "Packages")

--- a/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
@@ -3,11 +3,7 @@
     @foreach (var page in Model.Content.AncestorOrSelf(1).Children.Where("Visible"))
     {
     <li class="@(page.IsAncestorOrSelf(Model.Content) ? "current" : null)">
-        @if (page.Name == "Contribute")
-        {
-            <a href="https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/.github/CONTRIBUTING.md" target="_blank" rel="noreferrer noopener">@page.Name</a>
-        }
-        else if (page.Name == "Packages")
+        @if (page.Name == "Packages")
         {
             <a href="/about-packages">@page.Name</a>
         }

--- a/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
@@ -2,16 +2,16 @@
 <ul>
     @foreach (var page in Model.Content.AncestorOrSelf(1).Children.Where("Visible"))
     {
-    <li class="@(page.IsAncestorOrSelf(Model.Content) ? "current" : null)">
-        @if (page.Name == "Packages")
-        {
-            <a href="/about-packages">@page.Name</a>
-        }
-        else
-        {
-            <a href="@page.Url">@page.Name</a>
-        }
-    </li>
+        <li class="@(page.IsAncestorOrSelf(Model.Content) ? "current" : null)">
+            @if (page.Name == "Packages")
+            {
+                <a href="/about-packages">@page.Name</a>
+            }
+            else
+            {
+                <a href="@page.Url">@page.Name</a>
+            }
+        </li>
     }
 
     <li>
@@ -19,6 +19,7 @@
         {
             <div class="user">
                 @Html.Raw(MemberData.AvatarHtml)
+
                 @if (MemberData.AvatarImageTooSmall)
                 {
                     <span class="notificationCount">1</span>

--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -649,10 +649,6 @@
                     <match url="download/progress(/|)$" />
                     <action type="Redirect" redirectType="Permanent" appendQueryString="true" url="download/releases/progress" />
                 </rule>
-                <rule name="Contribute" patternSyntax="Wildcard">
-                    <match url="contribute*" />
-                    <action type="Redirect" redirectType="Permanent" appendQueryString="true" url="https://github.com/umbraco/Umbraco-CMS/blob/dev-v8/.github/CONTRIBUTING.md" />
-                </rule>
                 <rule name="CommunityCalendarYear">
                     <match url="^community/calendar/([0-9]{4})(/|)$" />
                     <action type="Rewrite" url="community/calendar/?year={R:1}" />


### PR DESCRIPTION
**What**
This PR removes the redirect to Github on /contribute.

**Why?**
We will be creating a new one (contribute page) and therefore need the ability to use that path. :) 