### PR TITLE
Add link to Heartcore docs before contribute

### DIFF
--- a/OurUmbraco/Documentation/DocumentationUpdater.cs
+++ b/OurUmbraco/Documentation/DocumentationUpdater.cs
@@ -115,6 +115,8 @@ namespace OurUmbraco.Documentation
                             return 5;
                         case "umbraco-cloud":
                             return 6;
+                        case "umbraco-heartcore":
+                            return 7;
                     }
                     break;
 


### PR DESCRIPTION
This adds Heartcore to the menu-order-building-whatever thingy so Heartcore stands next to Cloud.

Before:
![image](https://user-images.githubusercontent.com/4366314/69947940-01504b00-14ef-11ea-9e50-a95658412d64.png)


After:
![image](https://user-images.githubusercontent.com/4366314/69947923-fb5a6a00-14ee-11ea-8e48-c2854bdb3f15.png)
