### PR TITLE
Use Github username as fallback if no name is provided

### DIFF
--- a/OurUmbraco/Our/Controllers/LoginController.cs
+++ b/OurUmbraco/Our/Controllers/LoginController.cs
@@ -344,8 +344,10 @@ namespace OurUmbraco.Our.Controllers
                 return GetErrorResult("A member with that email address already exists.");
             }
 
+            // Since names are not mandatory on Github we use the username as fallback
+            var name = !string.IsNullOrWhiteSpace(user.Name) ? user.Name : user.Login;
 
-            var member = memberService.CreateMember(email, email, user.Name, "member");
+            var member = memberService.CreateMember(email, email, name, "member");
             member.SetValue("github", user.Login);
             member.SetValue("githubId", user.Id);
             member.SetValue("githubData", user.JObject.ToString());


### PR DESCRIPTION
Fixes ArgumentNullException when no name is provided on Github