### PR TITLE
New anon db available to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,19 @@ gulp
 
 ## Database Restore
 
-Download the SQL Server Database from: https://umbracoreleases.blob.core.windows.net/ourumbraco/OurDev20190430.zip.
+Download the SQL Server Database from: http://umbracoreleases.blob.core.windows.net/ourumbraco/OurDev20200107.7z.
 
-Restore the database to SQL Server 2016 SP1 (won't work on earlier version) and update the connection strings (`umbracoDbDSN`) in `OurUmbraco.Site/web.config`.
+Restore the database to SQL Server 2017 (won't work on earlier versions) and update the connection strings (`umbracoDbDSN`) in `OurUmbraco.Site/web.config`.
+
+If your SQL Server instance has the 'containment' feature enabled you can use these credentials in your connection string:
+`user id=OurDevAnon;password=gQW435Jg32;`
 
 ## Logging in
 
 All users and members use the same password: Not_A_Real_Password
 
-To log in, try `root` / `Not_A_Real_Password` for the backoffice and `member423@non-existing-mail-provider.none` / `Not_A_Real_Password` for the frontend.
+* Backoffice login to use: `root` / `Not_A_Real_Password`
+* Frontend login to use: `member_login@umbraco.org` / `Not_A_Real_Password`
 
 You will need to set requireSSL in the `Web.Config` to **false** to login to the frontend.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gulp
 
 ## Database Restore
 
-Download the SQL Server Database from: https://umbracoreleases.blob.core.windows.net/ourumbraco/OurDev20200107.7z.
+Download the SQL Server Database from: https://umbracoreleases.blob.core.windows.net/ourumbraco/OurDev20200107.7z.  If you don't have the 7zip utility installed you can download it from [7-zip.org](https://www.7-zip.org/) 
 
 Restore the database to SQL Server 2017 (won't work on earlier versions) and update the connection strings (`umbracoDbDSN`) in `OurUmbraco.Site/web.config`.
 
@@ -29,8 +29,9 @@ If your SQL Server instance has the 'containment' feature enabled you can use th
 
 All users and members use the same password: Not_A_Real_Password
 
-* Backoffice login to use: `root` / `Not_A_Real_Password`
-* Frontend login to use: `member_login@umbraco.org` / `Not_A_Real_Password`
+* To log into the backoffice use  `root` / `Not_A_Real_Password`.
+
+* To log into the frontend use `member_login@umbraco.org` / `Not_A_Real_Password`. You will be logging as Sebastiaan from Umbraco HQ.  All other profile information is anonymous.
 
 You will need to set requireSSL in the `Web.Config` to **false** to login to the frontend.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gulp
 
 ## Database Restore
 
-Download the SQL Server Database from: http://umbracoreleases.blob.core.windows.net/ourumbraco/OurDev20200107.7z.
+Download the SQL Server Database from: https://umbracoreleases.blob.core.windows.net/ourumbraco/OurDev20200107.7z.
 
 Restore the database to SQL Server 2017 (won't work on earlier versions) and update the connection strings (`umbracoDbDSN`) in `OurUmbraco.Site/web.config`.
 


### PR DESCRIPTION
I've updated the location to a recently generated database that can be used for running Our locally. 

I've also added a note about the user/password that can be used if your SQL Server instance has containment enabled.  

To enable containment you would need to run the following SQL.   

```
sp_configure 'contained database authentication', 1;  
GO  
RECONFIGURE;  
GO  
```

Using these credentials in your web.config connection string is super useful as it means that you won't need to reconfigure a login after each future DB restore.  But perhaps it's all sounding a bit complicated, so I should remove the sentence with the containment credentials?!

Am going to ask the rest of the Package Team to have a look at this and will submit the PR when some others have confirmed that this db works as expected