### PR TITLE
Package page banner

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_note.scss
+++ b/OurUmbraco.Client/src/scss/elements/_note.scss
@@ -7,4 +7,17 @@
     bottom: auto;
     margin-bottom: 30px;
     border-radius: 4px;
+
+    div {
+        text-align: center;
+    }
+
+    a {
+        padding: 10px;
+        border: 1px solid #fff;
+        text-decoration: none;
+        display: inline-block;
+        margin: 20px 10px 10px 10px;
+        border-radius: 4px;
+    }
 }

--- a/OurUmbraco.Client/src/scss/elements/_note.scss
+++ b/OurUmbraco.Client/src/scss/elements/_note.scss
@@ -17,7 +17,7 @@
         border: 1px solid #fff;
         text-decoration: none;
         display: inline-block;
-        margin: 20px 10px 10px 10px;
+        margin: 20px 10px 0px 10px;
         border-radius: 4px;
     }
 }

--- a/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Navigation/TopNavigation.cshtml
@@ -7,10 +7,6 @@
         {
             <a href="https://github.com/umbraco/Umbraco-CMS/blob/v8/dev/.github/CONTRIBUTING.md" target="_blank" rel="noreferrer noopener">@page.Name</a>
         }
-        else if (page.Name == "Packages")
-        {
-            <a href="/about-packages">@page.Name</a>
-        }
         else
         {
             <a href="@page.Url">@page.Name</a>

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -102,6 +102,13 @@
         <strong>Pages:</strong> @pages
     </p>
 }
+<div class="note">
+    <div>
+        <p>Want to learn more about the package initiative or sign up for the newsletter?</p>
+        
+        <a href="/about-packages">About packages</a><a href="/about-packages#package-newsletter">Newsletter</a><a href="/documentation/Extending/Packages/">Documentation</a>
+    </div>
+</div>
 <div class="search-big">
     <input type="search" class="project-search-input" required placeholder="Search for packages">
     <label for="search">Search packages</label>
@@ -138,7 +145,7 @@
         if (orderedVersions.Length == 1)
             return orderedVersions.First().ToString();
 
-        if(orderedVersions.Min() == orderedVersions.Max())
+        if (orderedVersions.Min() == orderedVersions.Max())
             return orderedVersions.Min().ToString();
 
         return orderedVersions.Min() + " - " + orderedVersions.Max();
@@ -228,8 +235,8 @@
                     </div>
                 </div>
             </div>
-                                }
-                            }
+        }
+    }
     <nav class="pagination" role="navigation">
         @if (page > 1)
         {

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -104,9 +104,9 @@
 }
 <div class="note">
     <div>
-        <p>Want to learn more about the package initiative or sign up for the newsletter?</p>
+        <p>Want to learn more about the package initiative?</p>
         
-        <a href="/about-packages">About packages</a><a href="/about-packages#package-newsletter">Newsletter</a><a href="/documentation/Extending/Packages/">Documentation</a>
+        <a href="/about-packages">Package initiative</a><a href="/about-packages#package-newsletter">Sign up for newsletter</a><a href="/documentation/Extending/Packages/">Documentation</a>
     </div>
 </div>
 <div class="search-big">


### PR DESCRIPTION
Had some requests to not automatically redirect to the about packages page from the top menu.

Now it will redirect to the package overview as it used to, but have a banner at the top that links to the about page:
![image](https://user-images.githubusercontent.com/36075913/72076809-74bb5880-32f6-11ea-9408-06c2f25c3a33.png)

The style of the banner is the same as on https://our.umbraco.com/community/ and I have added a bit to the styling for it, but nothing that will affect the current banner as it doesn't contain <div> or <a> elements 🙂
