### PR TITLE
Redirecting Umbraco 8 Docs status page to Docs pag

### DIFF
--- a/OurUmbraco.Site/config/IISRewriteMaps.config
+++ b/OurUmbraco.Site/config/IISRewriteMaps.config
@@ -356,6 +356,8 @@
 		
 		<add key="documentation/Extending/Language-Files/Language-Files-For-Packages" value="/documentation/Extending/Packages/Language-Files-For-Packages/" />
 		
+		<add key="documentation/v8documentation" value="/Documentation/" />
+		
 		<add key="documentation/reference/api" value="/documentation/Reference/Routing/WebApi/" />
 		<add key="documentation/reference/api/base/helloworld" value="/documentation/Reference/Routing/WebApi/" />
 		<add key="documentation/reference/api/base" value="/documentation/Reference/Routing/WebApi/" />


### PR DESCRIPTION
Since it's almost a year ago Umbraco 8 was relaesed, I'm removing the Docs status page.

PR: https://github.com/umbraco/UmbracoDocs/pull/2231 