### PR TITLE
Package stats

### DIFF
--- a/OurUmbraco.Site/Views/Apps.cshtml
+++ b/OurUmbraco.Site/Views/Apps.cshtml
@@ -12,16 +12,18 @@
     var currentDateTime = DateTime.Now;
     var downloadsThisMonth = packagesService.GetTopXMonthlyPackageDownloads(currentDateTime, 30);
     var downloadsLastMonth = packagesService.GetTopXMonthlyPackageDownloads(currentDateTime.AddMonths(-1), 30);
+    var downloadsPastYear = packagesService.GetTopXYearlyPackageDownloads(30);
 }
 
-<div id="body" class="page markdown-syntax">
-    <div>
-        @Html.Action("Render", "Breadcrumb", new { linkToCurrent = false })
-    </div>
+    <div id="body" class="page markdown-syntax">
+        <div>
+            @Html.Action("Render", "Breadcrumb", new { linkToCurrent = false })
+        </div>
 
-    @RenderTable(0, downloadsThisMonth)
-    @RenderTable(-1, downloadsLastMonth)
-</div>
+        @RenderTable(@DateTime.Now.AddMonths(0).ToString("Y"), downloadsThisMonth)
+        @RenderTable(@DateTime.Now.AddMonths(-1).ToString("Y"), downloadsLastMonth)
+        @RenderTable($"{@DateTime.Now.AddMonths(-12):Y} - {@DateTime.Now.AddMonths(0):Y}", downloadsPastYear)
+    </div>
 
 <style type="text/css">
     .page, .container {
@@ -69,9 +71,9 @@
     }
 </style>
 
-@helper RenderTable(int amountOfMonthsAgo, IEnumerable<PackagesService.PackageDownloads> data)
+@helper RenderTable(string headlineTime, IEnumerable<PackagesService.PackageDownloads> data)
 {
-    <h1>Top 30 packages by downloads - @DateTime.Now.AddMonths(amountOfMonthsAgo).ToString("Y")</h1>
+    <h1>Top 30 packages by downloads - @headlineTime</h1>
     <section>
         <div class="container">
             <div class="row">

--- a/OurUmbraco.Site/Views/Apps.cshtml
+++ b/OurUmbraco.Site/Views/Apps.cshtml
@@ -8,7 +8,10 @@
         Response.Redirect("/");
     }
     var packagesService = new PackagesService();
-    var data = packagesService.GetPackageStatisticsData();
+
+    var currentDateTime = DateTime.Now;
+    var downloadsThisMonth = packagesService.GetTopXMonthlyPackageDownloads(currentDateTime, 30);
+    var downloadsLastMonth = packagesService.GetTopXMonthlyPackageDownloads(currentDateTime.AddMonths(-1), 30);
 }
 
 <div id="body" class="page markdown-syntax">
@@ -16,44 +19,8 @@
         @Html.Action("Render", "Breadcrumb", new { linkToCurrent = false })
     </div>
 
-    <h1>Packages data</h1>
-    <section>
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12">
-                    <table class="overview">
-                        <tr>
-                            <td nowrap><strong>Name</strong></td>
-                            <td nowrap><strong>Owner</strong></td>
-                            <td nowrap><strong>Created</strong></td>
-                            <td nowrap><strong>Updated</strong></td>
-                            <td nowrap><strong>Version</strong></td>
-                            <td nowrap><strong>Compatibility</strong></td>
-                            <td nowrap><strong>License</strong></td>
-                            <td nowrap><strong>Documentation</strong></td>
-                            <td nowrap><strong>Votes</strong></td>
-                            <td nowrap><strong>Downloads</strong></td>
-                        </tr>
-                        @foreach (var package in data)
-                        {
-                            <tr>
-                                <td>@package.Name</td>
-                                <td nowrap>@package.Owner</td>
-                                <td nowrap>@package.Created</td>
-                                <td nowrap>@package.Updated</td>
-                                <td nowrap>@package.Version</td>
-                                <td nowrap>@package.Compatibility</td>
-                                <td nowrap>@package.License</td>
-                                <td nowrap>@package.HasDocumentation</td>
-                                <td nowrap>@package.Votes</td>
-                                <td nowrap>@package.Downloads</td>
-                            </tr>                            
-                        }
-                    </table>
-                </div>
-            </div>
-        </div>
-    </section>
+    @RenderTable(0, downloadsThisMonth)
+    @RenderTable(-1, downloadsLastMonth)
 </div>
 
 <style type="text/css">
@@ -64,6 +31,7 @@
     .overview {
         width: 1800px;
     }
+
     .overview td {
         font-size: 14px;
         vertical-align: top;
@@ -100,3 +68,37 @@
         font-size: 12px;
     }
 </style>
+
+@helper RenderTable(int amountOfMonthsAgo, IEnumerable<PackagesService.PackageDownloads> data)
+{
+    <h1>Top 30 packages by downloads - @DateTime.Now.AddMonths(amountOfMonthsAgo).ToString("Y")</h1>
+    <section>
+        <div class="container">
+            <div class="row">
+                <div class="col-md-12">
+                    <table class="overview">
+                        <tr>
+                            <td nowrap><strong>Package ID</strong></td>
+                            <td nowrap><strong>Create Date</strong></td>
+                            <td nowrap><strong>Author</strong></td>
+                            <td nowrap><strong>Downloads</strong></td>
+                        </tr>
+                        @foreach (var package in data)
+                        {
+                            var node = Umbraco.TypedContent(package.ProjectId);
+                            var owner = "";
+                            owner = node.GetPropertyValue("owner") != null ? Members.GetById(node.GetPropertyValue<int>("owner")).Name : "Owner is not set";
+
+                            <tr>
+                                <td><a href="@node.Url" target="_blank">@node.Name</a></td>
+                                <td nowrap>@node.CreateDate</td>
+                                <td nowrap>@owner</td>
+                                <td nowrap>@package.DownloadCount</td>
+                            </tr>
+                        }
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+}

--- a/OurUmbraco/Our/Services/PackagesService.cs
+++ b/OurUmbraco/Our/Services/PackagesService.cs
@@ -28,7 +28,7 @@ namespace OurUmbraco.Our.Services
         {
             var formattedDateTime = dateTime.ToString("yyyy-MM-ddTHH:mm:ss");
 
-            var packages = ApplicationContext.Current.DatabaseContext.Database.Fetch<PackageDownloads>($"SELECT TOP {amountOfRecords} projectId, COUNT(projectId) as downloadCount" +
+            var packages = _database.Fetch<PackageDownloads>($"SELECT TOP {amountOfRecords} projectId, COUNT(projectId) as downloadCount" +
                                                                                   $" FROM projectDownload" +
                                                                                   $" WHERE DATEPART(m, [timestamp]) = DATEPART(m, '{formattedDateTime}')" +
                                                                                   $" AND DATEPART(yyyy, [timestamp]) = DATEPART(yyyy, '{formattedDateTime}')" +
@@ -42,7 +42,7 @@ namespace OurUmbraco.Our.Services
         {
             var formattedDateTime = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss");
 
-            var packages = ApplicationContext.Current.DatabaseContext.Database.Fetch<PackageDownloads>($"SELECT TOP {amountOfRecords} projectId, COUNT(projectId) as downloadCount" +
+            var packages = _database.Fetch<PackageDownloads>($"SELECT TOP {amountOfRecords} projectId, COUNT(projectId) as downloadCount" +
                                                                                                        $" FROM projectDownload" +
                                                                                                        $" WHERE [timestamp] > DATEADD(year, -1, '{formattedDateTime}')" +
                                                                                                        $" GROUP BY projectId" +

--- a/OurUmbraco/Our/Services/PackagesService.cs
+++ b/OurUmbraco/Our/Services/PackagesService.cs
@@ -1,13 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using OurUmbraco.Repository.Services;
-using OurUmbraco.Wiki.BusinessLogic;
-using OurUmbraco.Wiki.Extensions;
 using Umbraco.Core;
 using Umbraco.Core.Persistence;
-using Umbraco.Web;
-using Umbraco.Web.Security;
 
 namespace OurUmbraco.Our.Services
 {
@@ -55,64 +49,6 @@ namespace OurUmbraco.Our.Services
         {
             public int ProjectId { get; set; }
             public int DownloadCount { get; set; }
-        }
-
-        public List<Package> GetPackageStatisticsData()
-        {
-            var packages = new List<Package>();
-
-            var umbracoContext = UmbracoContext.Current;
-            var prs = new PackageRepositoryService(new UmbracoHelper(umbracoContext), new MembershipHelper(umbracoContext), UmbracoContext.Current.Application.DatabaseContext);
-            var allPackages = prs.GetPackages(0, 2000);
-            var allPackagesPackages = allPackages.Packages;
-
-            var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-            var allPackagesContent= umbracoHelper.TypedContentAtXPath("//Project").ToList();
-
-            foreach (var package in allPackagesPackages)
-            {
-                var packageContent = allPackagesContent.FirstOrDefault(x => 
-                    string.Equals(x.GetPropertyValue<string>("packageGuid"), package.Id.ToString(), StringComparison.InvariantCultureIgnoreCase));
-
-                var pkgFiles = new List<WikiFile>();
-                if (packageContent != null)
-                    pkgFiles = WikiFile.CurrentFiles(packageContent.Id).OrderByDescending(x => x.CreateDate).ToList();
-
-                var statisticsPackage = new Package
-                {
-                    Name = package.Name,
-                    Owner = package.OwnerInfo.Owner,
-                    Created = package.Created.ToString("yyyy-MM-dd"),
-                    Updated = (pkgFiles.Any() ? pkgFiles.First().CreateDate : DateTime.MinValue).ToString("yyyy-MM-dd"),
-                    Version = package.LatestVersion.TrimStart('v', 'V'),
-                    Compatibility = pkgFiles.Any() ? pkgFiles.First().Version.Version : string.Empty,
-                    Compatibility2 = pkgFiles.Any() ? pkgFiles.First().Versions.ToVersionString().Replace(" ", string.Empty) : string.Empty,
-                    License = packageContent?.GetPropertyValue<string>("licenseName") ?? string.Empty,
-                    HasDocumentation = pkgFiles.Any(x => x.FileType == "docs"),
-                    Votes = package.Likes,
-                    Downloads = package.Downloads
-                };
-
-                packages.Add(statisticsPackage);
-            }
-            
-
-            return packages;
-        }
-
-        public class Package
-        {
-            public string Name { get; set; }
-            public string Owner { get; set; }
-            public string Created { get; set; }
-            public string Updated { get; set; }
-            public string Version { get; set; }
-            public string Compatibility { get; set; }
-            public string License { get; set; }
-            public bool HasDocumentation { get; set; }
-            public int Votes { get; set; }
-            public int Downloads { get; set; }
-            public string Compatibility2 { get; set; }
         }
     }
 }

--- a/OurUmbraco/Our/Services/PackagesService.cs
+++ b/OurUmbraco/Our/Services/PackagesService.cs
@@ -38,6 +38,19 @@ namespace OurUmbraco.Our.Services
             return packages;
         }
 
+        public IEnumerable<PackageDownloads> GetTopXYearlyPackageDownloads(int amountOfRecords)
+        {
+            var formattedDateTime = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss");
+
+            var packages = ApplicationContext.Current.DatabaseContext.Database.Fetch<PackageDownloads>($"SELECT TOP {amountOfRecords} projectId, COUNT(projectId) as downloadCount" +
+                                                                                                       $" FROM projectDownload" +
+                                                                                                       $" WHERE [timestamp] > DATEADD(year, -1, '{formattedDateTime}')" +
+                                                                                                       $" GROUP BY projectId" +
+                                                                                                       $" ORDER BY downloadCount DESC");
+
+            return packages;
+        }
+
         public class PackageDownloads
         {
             public int ProjectId { get; set; }


### PR DESCRIPTION
@nul800sebastiaan 

This implementation is not caching the db calls - it does 3 calls per page hit and the page is only for hq. Should it be cached?

I also left in the old GetPackageStatisticsData() method, but am not using it - should it just be removed? 🙂