### PR TITLE
Allow order by downloads

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -165,7 +165,7 @@
     }
 }
 <h1>Browse @headline packages</h1>
-<p><em>A total of @total packages match your current criteria</em></p>
+<p><em>@( total == 1 ? $"{total} package found" : $"{total} packages found")</em></p>
 <script type="text/template" class="search-item-project">
     <div class="box">
         <div class="row">

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -22,6 +22,10 @@
     {
         headline = "recently updated";
     }
+    else if (orderMode == "downloads")
+    {
+        headline = "most downloaded";
+    }
 
     if (version != null)
     {
@@ -36,7 +40,7 @@
     //MUST be live
     searchFilters.Filters.Add(new SearchFilter("projectLive", "1"));
 
-    if(orderMode == "popularity")
+    if(orderMode == "popularity" || orderMode == "downloads")
     {
         searchFilters.Filters.Add(new SearchFilter("isRetired", "0"));
     }
@@ -82,6 +86,9 @@
     else if (examineOrder == "createDate")
     {
         examineOrder = string.Concat(orderMode, "[Type=LONG]");
+    } else if (examineOrder == "downloads")
+    {
+        examineOrder = string.Concat(orderMode, "[Type=INT]");
     }
 
     //TODO: cache for 1 minute with this key just need to ensure the enumerable in the result is finalized
@@ -158,6 +165,7 @@
     }
 }
 <h1>Browse @headline packages</h1>
+<p><em>A total of @total packages match your current criteria</em></p>
 <script type="text/template" class="search-item-project">
     <div class="box">
         <div class="row">

--- a/OurUmbraco.Site/Views/Projects.cshtml
+++ b/OurUmbraco.Site/Views/Projects.cshtml
@@ -10,10 +10,11 @@
                 <nav>
                     <ul class="level-1">
                         <li class="filter-orderBy">
-                            <h3>Packages</h3>
+                            <h3>Order packages</h3>
                             <ul class="level-2">
-                                <li class="param-updateDate"><h4><a href="?orderBy=updateDate">Updated packages</a></h4></li>
-                                <li class="param-popularity"><h4><a href="?orderBy=popularity">Popular packages</a></h4></li>
+                                <li class="param-updateDate"><h4><a href="?orderBy=updateDate">Newest update</a></h4></li>
+                                <li class="param-popularity"><h4><a href="?orderBy=popularity">Popularity</a></h4></li>
+                                <li class="param-downloads"><h4><a href="?orderBy=downloads">Most downloaded</a></h4></li>
                             </ul>
                         </li>
                         <li class="filter-version">


### PR DESCRIPTION
Allows users to order by downloads as well as popularity and last update:
![image](https://user-images.githubusercontent.com/36075913/74085286-e4e50780-4a77-11ea-935b-37eb94a84a85.png)

Additionally added a little indicator of how many packages are in the search results as that was never apparent before.