### PR TITLE
Implementing REST endpoints to replace WCF

### DIFF
--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -157,6 +157,8 @@
     <connectionStrings>
         <remove name="umbracoDbDSN" />
         <add name="umbracoDbDSN" connectionString="#{connectionString}#" providerName="System.Data.SqlClient" />
+        <remove name="umbracoUpdate" />
+        <add name="umbracoUpdate" connectionString="#{connectionString2}#" providerName="System.Data.SqlClient" />
         <!-- Important: If you're upgrading Umbraco, do not clear the connection string / provider name during your web.config merge. -->
     </connectionStrings>
     <system.data>

--- a/OurUmbraco/Our/Api/InstallationController.cs
+++ b/OurUmbraco/Our/Api/InstallationController.cs
@@ -1,0 +1,108 @@
+﻿using System.Web;
+using System.Web.Http;
+using OurUmbraco.Our.Models;
+using Umbraco.Core.Persistence;
+using Umbraco.Web.WebApi;
+
+namespace OurUmbraco.Our.Api
+{
+    public class InstallationController : UmbracoApiController
+    {
+        [HttpPost]
+        public IHttpActionResult Install(InstallationModel model)
+        {
+            if (!ModelState.IsValid)
+                throw new HttpResponseException(Request.CreateValidationErrorResponse(ModelState));
+
+            var hasError = !string.IsNullOrEmpty(model.Error);
+            var ipAddress = HttpContext.Current.Request.UserHostAddress;
+            var domainName = HttpContext.Current.Request.UserHostName;
+
+            if (string.IsNullOrWhiteSpace(model.VersionComment) == false)
+            {
+                // V8 nightlies are reporting versions like alpha.58.1927 - which is too long,
+                // the column in the database is only 10 chars. Abbreviating the version comment here will result in fewer 
+                // errors logged in people's installs and we can see how many people actually 
+                // try the nightlies
+                if (model.VersionComment.Length > 10 && model.VersionComment.Contains("alpha"))
+                {
+                    // V8 nightlies all start with "alpha"
+                    model.VersionComment = model.VersionComment.Replace("alpha", "a");
+                }
+                else
+                {
+                    if (model.VersionComment.Length > 0 && model.VersionComment.Length > 10)
+                        // truncate to 10 chars, the max size
+                        model.VersionComment = model.VersionComment.Substring(0, 10);
+                }
+            }
+
+            if (!model.InstallCompleted)
+            {
+                using (var umbracoUpdateDb = new Database("umbracoUpdate"))
+                {
+                    var insertCmd = @"INSERT INTO [installs]
+           ([completed]
+           ,[isUpgrade]
+           ,[errorLogged]
+           ,[installId]
+           ,[installStart]
+           ,[versionMajor]
+           ,[versionMinor]
+           ,[versionPatch]
+           ,[versionComment]
+           ,[ip]
+           ,[domain]
+           ,[userAgent])
+     VALUES
+           (@completed
+           ,@isUpgrade
+           ,@errorLogged
+           ,@installId
+           ,@installStart
+           ,@versionMajor
+           ,@versionMinor
+           ,@versionPatch
+           ,@versionComment
+           ,@ip
+           ,@domain
+           ,@userAgent)";
+
+                    umbracoUpdateDb.Execute(insertCmd, new
+                    {
+                        completed = model.InstallCompleted,
+                        isUpgrade = model.IsUpgrade,
+                        errorLogged = hasError,
+                        installId = model.InstallId,
+                        installStart = model.Timestamp,
+                        versionMajor = model.VersionMajor,
+                        versionMinor = model.VersionMinor,
+                        versionPatch = model.VersionPatch,
+                        versionComment = model.VersionComment,
+                        ip = ipAddress,
+                        domain = domainName,
+                        userAgent = model.UserAgent
+                    });
+                }
+            }
+            else
+            {
+                using (var umbracoUpdateDb = new Database("umbracoUpdate"))
+                {
+                    var updateCmd = @"UPDATE [installs]
+           SET [completed] = 1, [installEnd] = @installEnd, [dbProvider] = @dbProvider 
+            WHERE installId = @installId";
+
+                    umbracoUpdateDb.Execute(updateCmd, new
+                    {
+                        installId = model.InstallId,
+                        installEnd = model.Timestamp,
+                        dbProvider = model.DbProvider
+                    });
+                }
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/OurUmbraco/Our/Api/UpgradeCheckController.cs
+++ b/OurUmbraco/Our/Api/UpgradeCheckController.cs
@@ -1,0 +1,108 @@
+﻿using System.Web;
+using System.Web.Http;
+using OurUmbraco.Our.Models;
+using Umbraco.Core.Persistence;
+using Umbraco.Web.WebApi;
+
+namespace OurUmbraco.Our.Api
+{
+    public class UpgradeCheckController : UmbracoApiController
+    {
+        [HttpPost]
+        public IHttpActionResult Install(InstallationModel model)
+        {
+            if (!ModelState.IsValid)
+                throw new HttpResponseException(Request.CreateValidationErrorResponse(ModelState));
+
+            var hasError = !string.IsNullOrEmpty(model.Error);
+            var ipAddress = HttpContext.Current.Request.UserHostAddress;
+            var domainName = HttpContext.Current.Request.UserHostName;
+
+            if (string.IsNullOrWhiteSpace(model.VersionComment) == false)
+            {
+                // V8 nightlies are reporting versions like alpha.58.1927 - which is too long,
+                // the column in the database is only 10 chars. Abbreviating the version comment here will result in fewer 
+                // errors logged in people's installs and we can see how many people actually 
+                // try the nightlies
+                if (model.VersionComment.Length > 10 && model.VersionComment.Contains("alpha"))
+                {
+                    // V8 nightlies all start with "alpha"
+                    model.VersionComment = model.VersionComment.Replace("alpha", "a");
+                }
+                else
+                {
+                    if (model.VersionComment.Length > 0 && model.VersionComment.Length > 10)
+                        // truncate to 10 chars, the max size
+                        model.VersionComment = model.VersionComment.Substring(0, 10);
+                }
+            }
+
+            if (!model.InstallCompleted)
+            {
+                using (var umbracoUpdateDb = new Database("umbracoUpdate"))
+                {
+                    var insertCmd = @"INSERT INTO [installs]
+           ([completed]
+           ,[isUpgrade]
+           ,[errorLogged]
+           ,[installId]
+           ,[installStart]
+           ,[versionMajor]
+           ,[versionMinor]
+           ,[versionPatch]
+           ,[versionComment]
+           ,[ip]
+           ,[domain]
+           ,[userAgent])
+     VALUES
+           (@completed
+           ,@isUpgrade
+           ,@errorLogged
+           ,@installId
+           ,@installStart
+           ,@versionMajor
+           ,@versionMinor
+           ,@versionPatch
+           ,@versionComment
+           ,@ip
+           ,@domain
+           ,@userAgent)";
+
+                    umbracoUpdateDb.Execute(insertCmd, new
+                    {
+                        completed = model.InstallCompleted,
+                        isUpgrade = model.IsUpgrade,
+                        errorLogged = hasError,
+                        installId = model.InstallId,
+                        installStart = model.Timestamp,
+                        versionMajor = model.VersionMajor,
+                        versionMinor = model.VersionMinor,
+                        versionPatch = model.VersionPatch,
+                        versionComment = model.VersionComment,
+                        ip = ipAddress,
+                        domain = domainName,
+                        userAgent = model.UserAgent
+                    });
+                }
+            }
+            else
+            {
+                using (var umbracoUpdateDb = new Database("umbracoUpdate"))
+                {
+                    var updateCmd = @"UPDATE [installs]
+           SET [completed] = 1, [installEnd] = @installEnd, [dbProvider] = @dbProvider 
+            WHERE installId = @installId";
+
+                    umbracoUpdateDb.Execute(updateCmd, new
+                    {
+                        installId = model.InstallId,
+                        installEnd = model.Timestamp,
+                        dbProvider = model.DbProvider
+                    });
+                }
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/OurUmbraco/Our/Api/UpgradeCheckController.cs
+++ b/OurUmbraco/Our/Api/UpgradeCheckController.cs
@@ -25,7 +25,7 @@ namespace OurUmbraco.Our.Api
 
             var latestVersion = GetLatestVersionFromMajor(model.VersionMajor);
             if (latestVersion == null)
-                return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.None, "", "")));
+                return Json(new UpgradeResult(UpgradeType.None, "", ""));
 
             // Persist the update check for our statistics, don't remove!
             var caller = HttpContext.Current.Request.UserHostName + "_" +
@@ -37,40 +37,40 @@ namespace OurUmbraco.Our.Api
 
             // Special case for 4.0.4.2, apperently we never recommended them to upgrade
             if (version == new System.Version(4, 0, 4, 2) || version == latestVersion)
-                return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.None, "", "")));
+                return Json(new UpgradeResult(UpgradeType.None, "", ""));
 
             if (version.Major == 4)
             {
                 // We had some special cases in the old updatechecker so I left them here
                 if (version == new System.Version(4, 0, 4, 1))
-                    return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.Minor, "4.0.4.2 is out with fixes for load-balanced sites.", "http://our.umbraco.org/download")));
+                    return Json(new UpgradeResult(UpgradeType.Minor, "4.0.4.2 is out with fixes for load-balanced sites.", "http://our.umbraco.org/download"));
 
                 if (version == new System.Version(4, 0, 4, 0))
-                    return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.Critical, "4.0.4.1 is out fixing a serious macro bug. Please upgrade!", "http://our.umbraco.org/download")));
+                    return Json(new UpgradeResult(UpgradeType.Critical, "4.0.4.1 is out fixing a serious macro bug. Please upgrade!", "http://our.umbraco.org/download"));
 
 
                 if (version == new System.Version(4, 7, 0, 0))
-                    return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.Critical, "This Umbraco installation needs to be upgraded. It may contain a potential security issue!", "http://our.umbraco.org/download")));
+                    return Json(new UpgradeResult(UpgradeType.Critical, "This Umbraco installation needs to be upgraded. It may contain a potential security issue!", "http://our.umbraco.org/download"));
 
 
                 if (version >= new System.Version(4, 10, 0, 0) && version < latestVersion)
-                    return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.Major, $"{latestVersion} is released. Upgrade today - it's free!", "http://our.umbraco.org/download")));
+                    return Json(new UpgradeResult(UpgradeType.Major, $"{latestVersion} is released. Upgrade today - it's free!", "http://our.umbraco.org/download"));
             }
 
             if (version.Major == 6)
             {
                 if ((version < latestVersion))
-                    return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.Major, $"{latestVersion} is released. Upgrade today - it's free!", "http://our.umbraco.org/download")));
+                    return Json(new UpgradeResult(UpgradeType.Major, $"{latestVersion} is released. Upgrade today - it's free!", "http://our.umbraco.org/download"));
             }
 
             if (version.Major == 7 || version.Major == 8 || version.Major > 8)
             {
                 if (version < latestVersion)
-                    return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.Minor, $"{latestVersion} is released. Upgrade today - it's free!", $"http://our.umbraco.org/contribute/releases/{latestVersion.Major}{latestVersion.Minor}{latestVersion.Build}")));
+                    return Json(new UpgradeResult(UpgradeType.Minor, $"{latestVersion} is released. Upgrade today - it's free!", $"http://our.umbraco.org/contribute/releases/{latestVersion.Major}{latestVersion.Minor}{latestVersion.Build}"));
             }
 
             // If nothing matches then it's probably a nightly or a very old version, no need to send upgrade message
-            return Ok(JsonConvert.SerializeObject(new UpgradeResult(UpgradeType.None, "", "")));
+            return Json(new UpgradeResult(UpgradeType.None, "", ""));
         }
 
         private void PersistUpdateCheck(string server, int majorVersion, int minorVersion, int patchVersion, string commentVersion)

--- a/OurUmbraco/Our/Api/UpgradeCheckController.cs
+++ b/OurUmbraco/Our/Api/UpgradeCheckController.cs
@@ -1,6 +1,12 @@
-﻿using System.Web;
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web;
 using System.Web.Http;
+using System.Web.Security;
+using Newtonsoft.Json;
 using OurUmbraco.Our.Models;
+using OurUmbraco.Our.Services;
 using Umbraco.Core.Persistence;
 using Umbraco.Web.WebApi;
 
@@ -103,6 +109,110 @@ namespace OurUmbraco.Our.Api
             }
 
             return Ok();
+        }
+
+        [HttpPost]
+        public IHttpActionResult CheckUpgrade(UpgradeModel model)
+        {
+            if (!ModelState.IsValid)
+                throw new HttpResponseException(Request.CreateValidationErrorResponse(ModelState));
+
+            int revision;
+            int.TryParse(model.VersionComment, out revision);
+            var version = new System.Version(model.VersionMajor, model.VersionMinor, model.VersionPatch, revision);
+
+            var latestVersion = GetLatestVersionFromMajor(model.VersionMajor);
+            if (latestVersion == null)
+                return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.None, "", "")));
+
+            // Persist the update check for our statistics, don't remove!
+            var caller = HttpContext.Current.Request.UserHostName + "_" +
+                         HttpContext.Current.Request.UserHostAddress;
+            var callerHashed = FormsAuthentication.HashPasswordForStoringInConfigFile(caller, "sha1");
+            PersistUpdateCheck(callerHashed, model.VersionMajor, model.VersionMinor, model.VersionPatch,
+                model.VersionComment);
+            // End of persisting the update check for our statistics, don't remove!
+
+            // Special case for 4.0.4.2, apperently we never recommended them to upgrade
+            if (version == new System.Version(4, 0, 4, 2) || version == latestVersion)
+                return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.None, "", "")));
+
+            if (version.Major == 4)
+            {
+                // We had some special cases in the old updatechecker so I left them here
+                if (version == new System.Version(4, 0, 4, 1))
+                    return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Minor, "4.0.4.2 is out with fixes for load-balanced sites.", "http://our.umbraco.org/download")));
+
+                if (version == new System.Version(4, 0, 4, 0))
+                    return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Critical, "4.0.4.1 is out fixing a serious macro bug. Please upgrade!", "http://our.umbraco.org/download")));
+
+
+                if (version == new System.Version(4, 7, 0, 0))
+                    return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Critical, "This Umbraco installation needs to be upgraded. It may contain a potential security issue!", "http://our.umbraco.org/download")));
+
+
+                if (version >= new System.Version(4, 10, 0, 0) && version < latestVersion)
+                    return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Major, $"{latestVersion} is released. Upgrade today - it's free!", "http://our.umbraco.org/download")));
+            }
+
+            if (version.Major == 6)
+            {
+                if ((version < latestVersion))
+                    return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Major, $"{latestVersion} is released. Upgrade today - it's free!", "http://our.umbraco.org/download")));
+            }
+
+            if (version.Major == 7 || version.Major == 8 || version.Major > 8)
+            {
+                if (version < latestVersion)
+                    return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Minor, $"{latestVersion} is released. Upgrade today - it's free!", $"http://our.umbraco.org/contribute/releases/{latestVersion.Major}{latestVersion.Minor}{latestVersion.Build}")));
+            }
+
+            return ResponseMessage(new HttpResponseMessage(HttpStatusCode.NoContent));
+        }
+
+        private void PersistUpdateCheck(string server, int majorVersion, int minorVersion, int patchVersion, string commentVersion)
+        {
+            if (commentVersion.Length > 49)
+            {
+                commentVersion = commentVersion.Substring(0, 47) + "...";
+            }
+
+            using (var umbracoUpdateDb = new Database("umbracoUpdate"))
+            {
+                var insertCmd = @"EXEC [UpdatePing]
+           @pinger, @major, @minor, @patch, @comment";
+
+                umbracoUpdateDb.Execute(insertCmd, new
+                {
+                    pinger = server,
+                    major = majorVersion,
+                    minor = minorVersion,
+                    patch = patchVersion,
+                    comment = commentVersion
+                });
+            }
+        }
+
+        private System.Version GetLatestVersionFromMajor(int major)
+        {
+            var releasesService = new ReleasesService();
+            var releases = releasesService.GetReleasesCache().Where(x => x.Released).OrderByDescending(x => x.FullVersion).ToList();
+            var majorVersionGroups = releases.GroupBy(x => x.FullVersion.Major).OrderByDescending(x => x.Key);
+
+            foreach (var majorVersion in majorVersionGroups)
+            {
+                if (majorVersion.Key == major)
+                {
+                    var releasesInGroup = releases.Where(x => x.FullVersion.Major == majorVersion.Key).ToList();
+                    var newestReleaseInGroup = releasesInGroup.First().FullVersion;
+                    var revision = (newestReleaseInGroup.Revision <= 0) ? 0 : newestReleaseInGroup.Revision;
+
+                    return new System.Version(newestReleaseInGroup.Major, newestReleaseInGroup.Minor,
+                        newestReleaseInGroup.Build, revision);
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/OurUmbraco/Our/Api/UpgradeCheckController.cs
+++ b/OurUmbraco/Our/Api/UpgradeCheckController.cs
@@ -167,7 +167,8 @@ namespace OurUmbraco.Our.Api
                     return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.Minor, $"{latestVersion} is released. Upgrade today - it's free!", $"http://our.umbraco.org/contribute/releases/{latestVersion.Major}{latestVersion.Minor}{latestVersion.Build}")));
             }
 
-            return ResponseMessage(new HttpResponseMessage(HttpStatusCode.NoContent));
+            // If nothing matches then it's probably a nightly or a very old version, no need to send upgrade message
+            return Ok(JsonConvert.SerializeObject(new UpgradeResultModel(UpgradeType.None, "", "")));
         }
 
         private void PersistUpdateCheck(string server, int majorVersion, int minorVersion, int patchVersion, string commentVersion)

--- a/OurUmbraco/Our/Models/InstallationModel.cs
+++ b/OurUmbraco/Our/Models/InstallationModel.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace OurUmbraco.Our.Models
+{
+    public class InstallationModel
+    {
+        private string _userAgent;
+        private string _versionComment;
+
+        public Guid InstallId { get; set; }
+        public bool IsUpgrade { get; set; }
+        public bool InstallCompleted { get; set; }
+        public DateTime Timestamp { get; set; }
+        public int VersionMajor { get; set; }
+        public int VersionMinor { get; set; }
+        public int VersionPatch { get; set; }
+
+        public string VersionComment
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_versionComment))
+                    _versionComment = "";
+                return _versionComment;
+            }
+            set { _versionComment = value; }
+        }
+        public string Error { get; set; }
+
+        public string UserAgent
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_userAgent))
+                    _userAgent = "blank";
+                return _userAgent;
+            }
+            set { _userAgent = value; }
+        }
+        public string DbProvider { get; set; }
+    }
+}

--- a/OurUmbraco/Our/Models/UpgradeModel.cs
+++ b/OurUmbraco/Our/Models/UpgradeModel.cs
@@ -1,0 +1,10 @@
+﻿namespace OurUmbraco.Our.Models
+{
+    public class UpgradeModel
+    {
+        public int VersionMajor { get; set; }
+        public int VersionMinor { get; set; }
+        public int VersionPatch { get; set; }
+        public string VersionComment { get; set; }
+    }
+}

--- a/OurUmbraco/Our/Models/UpgradeResult.cs
+++ b/OurUmbraco/Our/Models/UpgradeResult.cs
@@ -3,30 +3,30 @@ using Newtonsoft.Json.Converters;
 
 namespace OurUmbraco.Our.Models
 {
-    public enum UpgradeType
+    public class UpgradeResult
     {
-        None,
-        Patch,
-        Minor,
-        Major,
-        Critical,
-        Error,
-        OutOfSync
-    }
+        public enum UpgradeType
+        {
+            None,
+            Patch,
+            Minor,
+            Major,
+            Critical,
+            Error,
+            OutOfSync
+        }
 
-    public class UpgradeResultModel
-    {
         [JsonProperty(PropertyName = "upgradeType")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public UpgradeType UpgradeType { get; set; }
+        public UpgradeType CurrentUpgradeType { get; set; }
         [JsonProperty(PropertyName = "comment")]
         public string Comment { get; set; }
         [JsonProperty(PropertyName = "upgradeUrl")]
         public string UpgradeUrl { get; set; }
 
-        public UpgradeResultModel(UpgradeType upgradeType, string comment, string upgradeUrl)
+        public UpgradeResult(UpgradeType upgradeType, string comment, string upgradeUrl)
         {
-            UpgradeType = upgradeType;
+            CurrentUpgradeType = upgradeType;
             Comment = comment;
             UpgradeUrl = upgradeUrl;
         }

--- a/OurUmbraco/Our/Models/UpgradeResultModel.cs
+++ b/OurUmbraco/Our/Models/UpgradeResultModel.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace OurUmbraco.Our.Models
+{
+    public enum UpgradeType
+    {
+        None,
+        Patch,
+        Minor,
+        Major,
+        Critical,
+        Error,
+        OutOfSync
+    }
+
+    public class UpgradeResultModel
+    {
+        [JsonProperty(PropertyName = "upgradeType")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public UpgradeType UpgradeType { get; set; }
+        [JsonProperty(PropertyName = "comment")]
+        public string Comment { get; set; }
+        [JsonProperty(PropertyName = "upgradeUrl")]
+        public string UpgradeUrl { get; set; }
+
+        public UpgradeResultModel(UpgradeType upgradeType, string comment, string upgradeUrl)
+        {
+            UpgradeType = upgradeType;
+            Comment = comment;
+            UpgradeUrl = upgradeUrl;
+        }
+    }
+}

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -488,6 +488,7 @@
     <Compile Include="Location\LocationService.cs" />
     <Compile Include="Location\Models\Location.cs" />
     <Compile Include="Our\Api\DashboardStatisticsController.cs" />
+    <Compile Include="Our\Api\InstallationController.cs" />
     <Compile Include="Our\Api\MembersController.cs" />
     <Compile Include="Our\Api\OurMemberStatisticsController.cs" />
     <Compile Include="Our\Api\IssuesStatisticsController.cs" />
@@ -565,7 +566,7 @@
     <Compile Include="Our\Models\Releases.cs" />
     <Compile Include="Community\Models\TeamUmbraco.cs" />
     <Compile Include="Our\Models\UpgradeModel.cs" />
-    <Compile Include="Our\Models\UpgradeResultModel.cs" />
+    <Compile Include="Our\Models\UpgradeResult.cs" />
     <Compile Include="Our\Services\ContributorBadgeService.cs" />
     <Compile Include="Our\Services\EmailService.cs" />
     <Compile Include="Our\Models\ActivationEmailModel.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -565,6 +565,7 @@
     <Compile Include="Our\Models\Releases.cs" />
     <Compile Include="Community\Models\TeamUmbraco.cs" />
     <Compile Include="Our\Models\UpgradeModel.cs" />
+    <Compile Include="Our\Models\UpgradeResultModel.cs" />
     <Compile Include="Our\Services\ContributorBadgeService.cs" />
     <Compile Include="Our\Services\EmailService.cs" />
     <Compile Include="Our\Models\ActivationEmailModel.cs" />

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -542,6 +542,7 @@
     <Compile Include="Documentation\DocumentationContentFinder.cs" />
     <Compile Include="Documentation\Controllers\DocfxController.cs" />
     <Compile Include="Our\Api\GitHubController.cs" />
+    <Compile Include="Our\Api\UpgradeCheckController.cs" />
     <Compile Include="Our\EventHandlers\ReleaseEventHandler.cs" />
     <Compile Include="Our\Extensions\DateTimeExtension.cs" />
     <Compile Include="Our\Extensions\HtmlHelperExtensions.cs" />
@@ -557,11 +558,13 @@
     <Compile Include="Our\Models\GitHub\AutoReplies\GitHubAutoReplyType.cs" />
     <Compile Include="Our\Models\GitHub\Review.cs" />
     <Compile Include="Our\Models\GitHub\User.cs" />
+    <Compile Include="Our\Models\InstallationModel.cs" />
     <Compile Include="Our\Models\PullRequestContributor.cs" />
     <Compile Include="Our\Models\IssuesInPeriod.cs" />
     <Compile Include="Our\Models\PullRequestsInPeriod.cs" />
     <Compile Include="Our\Models\Releases.cs" />
     <Compile Include="Community\Models\TeamUmbraco.cs" />
+    <Compile Include="Our\Models\UpgradeModel.cs" />
     <Compile Include="Our\Services\ContributorBadgeService.cs" />
     <Compile Include="Our\Services\EmailService.cs" />
     <Compile Include="Our\Models\ActivationEmailModel.cs" />


### PR DESCRIPTION
The purpose of this PR is to replace http://update.umbraco.org/checkforupgrade.asmx

Two endpoints have been created:
- **Install**
  - This endpoint basically just writes to a database such that we have a count of installs of Umbraco
- **CheckUpgrade**
  - This endpoint receives the current Umbraco version, and if there exists a newer version of that major, it returns the information about the latest version of this major - otherwise, a None result is returned.

Before starting:
- Make sure to follow the instructions on Our https://github.com/umbraco/OurUmbraco for how to set up the project locally. 
- After that execute the script uploaded as an attachment to the AB issue (AB4954)
- After restoring the DB and having configured a user, in your web.config in `<connectionStrings>` section, add: 
 ```
<remove name="umbracoUpdate" />
        <add name="umbracoUpdate" connectionString="server=.\;database=upgradechecker;user id={USERNAME};password={PASSWORD};Connection Timeout=3600" providerName="System.Data.SqlClient" />
```
---

## Testing:
- **Install endpoint**
Using Postman for example you can make a POST request to `http://{localhost:24292}/umbraco/api/Installation/Install` with header - `Content-Type` : `application/json` - and body:
```
{
"InstallId":"B2E83361-1D5E-4D91-BB7A-94956413D28F",
"IsUpgrade":true,
"InstallCompleted":false,
"Timestamp":"2020-02-07T11:56:00",
"VersionMajor":7,
"VersionMinor":12,
"VersionPatch":1,
"VersionComment":"a",
"Error":"",
"UserAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
"DbProvider":"SqlServer"
}
```

This will insert a record in [upgradechecker][dbo].[installs] and field **[installEnd]** will be at first set to `NULL`. If you make the previous call again with `"InstallCompleted":true,` then the record will be updated with a timestamp for the end of the install.

---
</br>

- **CheckUpgrade endpoint**
Using Postman for example you can make a POST request to `http://{localhost:24292}/umbraco/api/UpgradeCheck/CheckUpgrade` with header - `Content-Type` : `application/json` - and body:
```
{
"VersionMajor":8,
"VersionMinor":4,
"VersionPatch":0,
"VersionComment":"0"
}
```
As this is the latest version in this repo you should receive the following response meaning there is nothing new to upgrade to:
`"{"upgradeType":"None","comment":"","upgradeUrl":""}"`. And if you check the DB - [upgradechecker].[dbo].[pings] you would have a record inserted there. Every time you make the same request, the field **[lastPing]** will be updating with the current timestamp.


⚠️ If you get an error that the `[lastPing]` or `[firstPing]` cannot be null, you need to update the SP `UpdatePing` to:
```
USE [upgradechecker]
GO
/****** Object:  StoredProcedure [dbo].[UpdatePing]    Script Date: 17-Feb-20 9:51:15 AM ******/
SET ANSI_NULLS ON
GO
SET QUOTED_IDENTIFIER ON
GO
ALTER proc [dbo].[UpdatePing](@pinger as nvarchar(255), @major as int, @minor as int, @patch as int, @comment as nvarchar(255)) as
if exists(select pinger from pings where pinger = @pinger) BEGIN
update pings set lastPing = getdate(), major = @major, minor = @minor, patch = @patch, comment = @comment where pinger = @pinger
END ELSE BEGIN
insert into pings (pinger, major, minor, patch, comment, firstPing, lastPing) values (@pinger, @major, @minor, @patch, @comment, getdate(), getdate())
END
```
_(Need to chat with Sebastiaan to update the script on the server)_

There are a few special cases:
| Version | Response |
| ------------- | ------------- |
| 4.0.4.2 | "None"  |
| 4.0.4.1 | "Minor" + "4.0.4.2 is out with fixes for load-balanced sites." |
| 4.0.4.0 | "Minor" + "4.0.4.1 is out fixing a serious macro bug. Please upgrade!" |
| 4.7.0.0 | "Minor" + "This Umbraco installation needs to be upgraded...." |

The rest versions before the latest should receive a response like:
`"{"upgradeType":"Minor","comment":"7.15.3.0 is released. Upgrade today - it's free!","upgradeUrl":"http://our.umbraco.org/contribute/releases/7153"}"`