### PR TITLE
Allow renaming packages

### DIFF
--- a/OurUmbraco/MarketPlace/NodeListing/NodeListingProvider.cs
+++ b/OurUmbraco/MarketPlace/NodeListing/NodeListingProvider.cs
@@ -9,7 +9,6 @@ using OurUmbraco.MarketPlace.Extensions;
 using OurUmbraco.MarketPlace.Interfaces;
 using OurUmbraco.MarketPlace.Providers;
 using OurUmbraco.Our;
-using OurUmbraco.Our.Controllers;
 using OurUmbraco.Our.Examine;
 using OurUmbraco.Wiki.Extensions;
 using umbraco;


### PR DESCRIPTION
This will fix https://github.com/umbraco/Umbraco.Packages/issues/44

Update 21st of April 2020:
The reason this hasn't been merged yet is that you will be able to create a package with the same name as an existing package as long as it is under a different category.

Fx. Call a package Umbraco Forms that is under Starter kits..

This is currently possible as well if you create a new package, so before this gets merged in some consideration is needed on how we can fix that issue.

Additionally if you rename it to an already existing name it will call it "Existing Name(1)" just like when making a node in the backoffice.