### PR TITLE
Robots txt update

### DIFF
--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -698,6 +698,7 @@
     <Content Include="projects\umbraco-pro\contour\Documentation\Installation\DeveloperSectionPackageRepoContourInstallPackageComplete.png" />
     <Content Include="projects\umbraco-pro\contour\Documentation\Installation\DeveloperSectionPackageRepoContourInstallPackageStatus.png" />
     <Content Include="projects\umbraco-pro\contour\Documentation\Installation\DeveloperSectionPackageRepoContourInstallPackageWait.png" />
+    <Content Include="robots.txt" />
     <Content Include="scripts\amcharts\charts.js" />
     <Content Include="scripts\amcharts\core.js" />
     <Content Include="scripts\amcharts\deps\canvg.js" />

--- a/OurUmbraco.Site/robots.txt
+++ b/OurUmbraco.Site/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow:/
-Disallow: /FileDownload?id=
+Disallow: /FileDownload

--- a/OurUmbraco.Site/robots.txt
+++ b/OurUmbraco.Site/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Disallow: /
+Allow:/
+Disallow: /FileDownload?id=


### PR DESCRIPTION
Included the robots.txt file in the site project so it get's deployed to the website. At the moment there is no robots.txt file.

The robots.txt file is updated so it allows indexing the site, but prevents crawlers from following links to filedownload page.

This could be the cause of  why some very old packages still get daily downloads and show up in the popular packages search.

Jesper checked Google Analytics and confirmed that these are not triggered by clicking in the browser on the download button.

