### PR TITLE
Unify Package search #554

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -1,7 +1,5 @@
-﻿@using Examine.SearchCriteria
-@using OurUmbraco.Our
-@using OurUmbraco.Our.Examine
-@using OurUmbraco.Project
+﻿@using OurUmbraco.Repository.Controllers
+@using OurUmbraco.Repository.Models
 @inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 @{
     //This is the main Our project search
@@ -20,7 +18,6 @@
         orderMode = dataMode;
     }
 
-
     var page = !string.IsNullOrEmpty(Request["page"]) ? int.Parse(Request["page"]) : 1;
     var category = Request["category"];
     var version = Request["version"];
@@ -31,119 +28,20 @@
         pageSize = (int)ViewData["pageSize"];
     }
 
-    var searchFilters = new SearchFilters(BooleanOperation.And);
-    //MUST be live
-    searchFilters.Filters.Add(new SearchFilter("projectLive", "1"));
-
-    if (orderMode == "popularity")
-    {
-        searchFilters.Filters.Add(new SearchFilter("isRetired", "0"));
-    }
-
-    var filters = new List<SearchFilters> { searchFilters };
-
-    if (!string.IsNullOrEmpty(category))
-    {
-        var categoryFilters = new SearchFilters(BooleanOperation.Or);
-        //NOTE: categories are indexed as lower case and are not tokenized so must be an exact match and therefore require quotes
-
-        if (category.ToLowerInvariant() == "uaas".ToLowerInvariant())
-        {
-            categoryFilters.Filters.Add(new SearchFilter("worksOnUaaS", string.Format("\"{0}\"", "True")));
-        }
-        else
-        {
-            categoryFilters.Filters.Add(new SearchFilter("categoryFolder", string.Format("\"{0}\"", category.ToLowerInvariant().Trim())));
-        }
-
-        filters.Add(categoryFilters);
-    }
-
-    if (!string.IsNullOrEmpty(version))
-    {
-        //need to clean up this string, it could be all sorts of things
-        var parsedVersion = version.GetFromUmbracoString();
-        if (parsedVersion != null)
-        {
-            var fromVersion = parsedVersion.GetNumericalValue();
-            var toVersion = new Version(parsedVersion.Major, 999, 999).GetNumericalValue();
-            var versionFilters = new SearchFilters(BooleanOperation.Or);
-            versionFilters.Filters.Add(new RangeSearchFilter("num_version", fromVersion, toVersion));
-            filters.Add(versionFilters);
-        }
-    }
-
-    var examineOrder = orderMode;
-    if (examineOrder == "popularity")
-    {
-        examineOrder = string.Concat(orderMode, "[Type=INT]");
-    }
-    else if (examineOrder == "createDate")
-    {
-        examineOrder = string.Concat(orderMode, "[Type=LONG]");
-    }
-
-    //TODO: cache for 1 minute with this key just need to ensure the enumerable in the result is finalized
-    //var key = string.Format("ListProjects.{0}.{1}.{2}.{3}.{4}", page, orderMode, term, version, category);
-    var searcher = new OurSearcher(term,
-    "project", null, examineOrder,
-    filters: filters, maxResults: pageSize * page);
-
-    var search = searcher.Search("projectSearcher");
-    var total = search.SearchResults.TotalItemCount;
-    var pages = (total / pageSize) + 1;
-
-    var result = search.SearchResults.Skip((page - 1) * pageSize).Take(pageSize);
-
     var url = string.Format("orderBy={0}&q={1}&version={2}&category={3}", orderMode, term, version, category);
+    
+    var searchOrder = GetSortOrder(orderMode);
+
+    var packageService = new OurUmbraco.Repository.Services
+        .PackageRepositoryService(Umbraco, Members, ApplicationContext.Current.DatabaseContext);
+
+    var results = packageService.GetPackages(page - 1, pageSize, category, term, version, searchOrder, false);
 }
 
-@functions{
-    public string GetField(IDictionary<string, string> fields, string field, string defaultVal = "")
-    {
-        if (fields != null && fields.ContainsKey(field))
-            return fields[field];
-
-        return defaultVal;
-    }
-
-    public string ParseVersion(SearchResult result)
-    {
-        var versions = result.GetValues("versions").ToList();
-        if (result.Fields.Keys.Contains("versions"))
-        {
-            versions.Add(result["versions"]);
-        }
-
-        var orderedVersions = versions
-            .Select(x =>
-            {
-                Version v;
-                return Version.TryParse(x, out v) ? v : null;
-            }).WhereNotNull()
-            .OrderByDescending(x => x)
-            .ToArray();
-
-        if (orderedVersions.Any() == false)
-            return "n/a";
-
-        if (orderedVersions.Length == 1)
-            return orderedVersions.First().ToString();
-
-        if (orderedVersions.Min() == orderedVersions.Max())
-            return orderedVersions.Min().ToString();
-
-        return orderedVersions.Min() + " - " + orderedVersions.Max();
-    }
-}
 <div class="packages-listing">
-    @foreach (var childPage in result)
+    @foreach (var childContent in results.Packages)
     {
-        var childContent = Umbraco.TypedContent(childPage.Id);
-        if (childContent != null)
-        {
-            @RenderProjectBox(childContent, childPage)
-        }
+        @RenderProjectBox(childContent)
     }
 </div>
 
@@ -155,12 +53,12 @@
             <a class="prev" href="?page=@(page - 1)&@url">Prev</a>
         }
 
-        @for (var i = (page - 1 > 0 ? page - 1 : 1); i < (page + (pagesToShowLeft - (page - 1 > 0 ? 1 : 0))) && i <= pages; i++)
+        @for (var i = (page - 1 > 0 ? page - 1 : 1); i < (page + (pagesToShowLeft - (page - 1 > 0 ? 1 : 0))) && i <= results.Pages; i++)
         {
             <a class="@Umbraco.If(i == page, "active")" href="?page=@i&@url">@i</a>
         }
 
-        @if (page < pages)
+        @if (page < results.Total)
         {
             <span>&hellip;</span>
             <a class="next" href="?page=@(page + 1)&@url">Next</a>
@@ -170,51 +68,63 @@
 else
 {
     @*
-    <nav role="navigation">
-        <a href="?page=1&orderBy=@orderMode">See more &raquo;</a>
-    </nav>
+        <nav role="navigation">
+            <a href="?page=1&orderBy=@orderMode">See more &raquo;</a>
+        </nav>
     *@
 }
 
 
-@helper RenderProjectBox(IPublishedContent projectContent, SearchResult projectResult)
+@helper RenderProjectBox(Package projectContent)
 {
     <a class="package-box" href="@projectContent.Url">
         <div class="package-image">
-            @RenderProjectImage(projectContent)
+            @RenderProjectImage(projectContent.Image)
         </div>
         <div class="package-info">
             <h3>@projectContent.Name</h3>
             <span class="text-fadeout"></span>
-            <p class="small">@Html.Raw(GetField(projectResult.Fields, "body", "No description available").StripHtml().Truncate(50))</p>
+            <p class="small">@projectContent.Summary</p>
         </div>
 
         <div class="other">
             <div class="package-badge">
-                <span class="package-number">@ParseVersion(projectResult)</span>
+                <span class="package-number">@projectContent.VersionRange</span>
             </div>
             <div class="stats">
                 <span class="karma">
-                    @GetField(projectResult.Fields, "karma", "0")<span><i class="icon-Hearts color-red"></i></span>
+                    @projectContent.Likes <span><i class="icon-Hearts color-red"></i></span>
                 </span>
                 <span class="downloads">
-                    @GetField(projectResult.Fields, "downloads", "0")<span><i class="icon-Download-alt"></i></span>
+                    @projectContent.Downloads <span><i class="icon-Download-alt"></i></span>
                 </span>
             </div>
         </div>
     </a>
 }
 
-@helper RenderProjectImage(IPublishedContent projectContent)
+@helper RenderProjectImage(string defaultScreenshot)
 {
-    var defaultScreenshot = "/css/img/package2.png";
-    if (projectContent != null)
+    <img src="@defaultScreenshot?width=64&height=64&bgcolor=fff&format=png"
+         srcset="@defaultScreenshot?width=128&height=128&bgcolor=fff&format=png 2x,
+             @defaultScreenshot?width=192&height=192&bgcolor=fff&format=png 3x" />
+}
+
+@functions{
+    public PackageSortOrder GetSortOrder(string orderMode)
     {
-        defaultScreenshot = projectContent.GetPropertyValue("defaultScreenshotPath", false, "/css/img/package2.png");
+        switch (orderMode.ToLower())
+        {
+            case "popularity":
+                return PackageSortOrder.Popular;
+            case "createdate":
+                return PackageSortOrder.Latest;
+            case "updatedate":
+                return PackageSortOrder.Default;
+            case "downloads":
+                return PackageSortOrder.Downloads;
+        }
+
+        return PackageSortOrder.Popular;
     }
-
-    <img src="@Utils.GetScreenshotPath(defaultScreenshot)?width=64&height=64&bgcolor=fff&format=png"
-         srcset="@Utils.GetScreenshotPath(defaultScreenshot)?width=128&height=128&bgcolor=fff&format=png 2x,
-             @Utils.GetScreenshotPath(defaultScreenshot)?width=192&height=192&bgcolor=fff&format=png 3x" />
-
 }

--- a/OurUmbraco.Site/Views/Partials/Projects/SortOrderDropdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/SortOrderDropdown.cshtml
@@ -10,5 +10,6 @@
     <option value="popularity" @Umbraco.If(orderBy == "popularity", "selected")>Popular</option>
     <option value="createDate" @Umbraco.If(orderBy == "createDate", "selected")>Latest</option>
     <option value="updateDate" @Umbraco.If(orderBy == "updateDate", "selected")>Updated</option>
+    <option value="downloads" @Umbraco.If(orderBy == "downloads", "selected")>Downloads</option>
 </select>
 

--- a/OurUmbraco.Site/Views/Projects.cshtml
+++ b/OurUmbraco.Site/Views/Projects.cshtml
@@ -206,7 +206,7 @@
         });
 
         $('#version').change(function () {
-            var cleanUrl = removeParams('page,orderBy', window.location.href);
+            var cleanUrl = removeParams('page', window.location.href);
             window.location.href = replaceQueryString(cleanUrl, 'version', $(this).val());
         });
 

--- a/OurUmbraco/Repository/Controllers/PackageSortOrder.cs
+++ b/OurUmbraco/Repository/Controllers/PackageSortOrder.cs
@@ -4,6 +4,7 @@ namespace OurUmbraco.Repository.Controllers
     {
         Default,
         Latest,
-        Popular
+        Popular,
+        Downloads
     }
 }

--- a/OurUmbraco/Repository/Models/Package.cs
+++ b/OurUmbraco/Repository/Models/Package.cs
@@ -36,5 +36,20 @@ namespace OurUmbraco.Repository.Models
         public PackageOwnerInfo OwnerInfo { get; set; }
         
         public long Score { get; set; }
+
+        /// <summary>
+        ///  path to the image, our.umbraco.com - has multiple crops
+        /// </summary>
+        public string Image { get; set; }
+
+        /// <summary>
+        ///  version range (e.g 7.4 - 8.5) for package
+        /// </summary>
+        public string VersionRange { get; set; }
+
+        /// <summary>
+        ///  shorter summary shown on our.umbraco.com
+        /// </summary>
+        public string Summary { get; set; }
     }
 }

--- a/OurUmbraco/Repository/Models/PagedPackages.cs
+++ b/OurUmbraco/Repository/Models/PagedPackages.cs
@@ -6,5 +6,6 @@ namespace OurUmbraco.Repository.Models
     {
         public IEnumerable<Package> Packages { get; set; }
         public int Total { get; set; }
+        public int Pages { get; set; }
     }
 }


### PR DESCRIPTION
For #554 

- [x] Use the `PackageRepositoryService` to return the packages for our.umbraco.org. 
- [x] Fix the Service Search so it no longer includes retired packages
- [x] Add download sort order to the package Service 
- [x] Add download sort order option to the our.umbraco.org filters
- [x] don't reset the sort order filter when people pick a new umbraco version. 

this has extended the `PackageRepositoryService` a little, but we have not changed any of the existing information used by the back office. 

**Because the Service returns everything with the base URL when you are testing this, all the package results will have fully qualified URLs to our.umbraco.org. (not your local site).**

I am not sure how to check the back office elements are still working, can i change something in a standard umbraco install to point its package list to my own version of our ?
