### PR TITLE
New RSS feed URL

### DIFF
--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -95,7 +95,7 @@
       "checkTitles": false,
       "title": "Umbraco HQ",
       "url": "https://umbraco.com/blog",
-      "rss": "https://umbraco.com/blog/rss-feed/",
+      "rss": "https://umbraco.com/rss/blog/",
       "logo": "https://our.umbraco.com/media/7514503/umbraco_logo_turquoise_transparent.png",
       "memberId": null
     },


### PR DESCRIPTION
The RSS feed has a new URL on the new umbraco.com website 😮 

I noticed that `https://umbraco.com/blog/rss-uprofile-feed/` redirects to `https://umbraco.com/rss/blog/?tag=uprofile`.

Would a similar redirect be possible from `https://umbraco.com/blog/rss-feed/` to `https://umbraco.com/rss/blog/`? Then it doesn't break for people using the old URL.