### PR TITLE
Reorganising member package listing to be under 'status' headings

### DIFF
--- a/OurUmbraco.Client/src/js/app.js
+++ b/OurUmbraco.Client/src/js/app.js
@@ -37,9 +37,10 @@ jQuery(document).ready(function () {
     // Tab
     $('.tabs li').click(function () {
         var tab_id = $(this).attr('data-tab');
+        var tab_container = $(this).closest("div");
 
-        $('.tabs li').removeClass('current');
-        $('.tab-content').removeClass('current');
+        $(tab_container).find('.tabs li').removeClass('current');
+        $(tab_container).find('.tab-content').removeClass('current');
 
         $(this).addClass('current');
         $("#" + tab_id).addClass('current');

--- a/OurUmbraco.Client/src/scss/elements/_profile.scss
+++ b/OurUmbraco.Client/src/scss/elements/_profile.scss
@@ -283,8 +283,8 @@
 
 .profile-settings-packages {
 	.button {
-		margin-top: 30px;
-		margin-bottom: 30px;
+		margin-top: 10px;
+		margin-bottom: 10px;
 
 		@media (max-width: $md) {
 			width: 100%;

--- a/OurUmbraco.Client/src/scss/elements/_profile.scss
+++ b/OurUmbraco.Client/src/scss/elements/_profile.scss
@@ -301,6 +301,51 @@
 	&.packages-content {
 		top: 0;
 	}
+
+	.packages-listing {
+
+		.tabs {
+			margin: 0px;
+			padding: 0px;
+			list-style: none;
+			margin-top: 2rem;
+
+			li {
+				background: #ededed;
+				color: $color-headline;
+				display: inline-block;
+				padding: 10px 15px;
+				cursor: pointer;
+				font-size: 1rem;
+				border: solid 1px #ededed;
+
+				&.current {
+					background: none;
+					color: $color-headline;
+				}
+
+				&:hover {
+					opacity: .8;
+				}
+			}
+		}
+
+		.tab-content {
+			display: none;
+			padding: 30px 15px;
+			margin-bottom: 4rem;
+
+			h3 {
+				font-size: 1.1rem;
+				margin-bottom: 1rem;
+				color: $color-headline;
+			}
+
+			&.current {
+				display: inherit;
+			}
+		}
+	}
 }
 
 .box {

--- a/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
@@ -39,7 +39,7 @@
         @if (Model.RetiredProjects.Any())
         {
             <strong>Retired Packages</strong>
-            <em>You have indicated that there projects are no longer being maintained. They are still visible in searches so that people can read the reason why it has been retired.</em>
+            <em>You have indicated that these projects are no longer being maintained. They are still visible in searches so that people can read the reason why it has been retired.</em>
             foreach (var project in Model.RetiredProjects)
             {
                 @RenderProject(project)

--- a/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
@@ -3,21 +3,49 @@
 @model OurUmbraco.Our.Models.MyProjectsModel
 
 <div class="profile-settings">
-    <strong>My Packages</strong>
     <div class="profile-settings-packages packages-content">
         <a href="/member/profile/projects/details?projectId=" class="button green"><i class="icon-Add"></i>Add package</a>
 
-        @foreach (var project in Model.Projects)
+        @if (Model.LiveProjects.Any())
         {
-            @RenderProject(project)
+            <strong>Active Packages</strong>
+            <em>Active packages are visible to everyone. If a package is no longer actively maintained please flag it as 'retired'.</em>
+            foreach (var project in Model.LiveProjects)
+            {
+                @RenderProject(project)
+            }
         }
-        
-        <strong>Package Contributions</strong>
-        @foreach (var project in Model.ContribProjects)
+
+        @if (Model.DraftProjects.Any())
         {
-            @RenderProject(project)
+            <strong>Draft Packages</strong>
+            <em>Draft packages are visible only to you, not anyone else.</em>
+            foreach (var project in Model.DraftProjects)
+            {
+                @RenderProject(project)
+            }
         }
-        
+
+        @if (Model.ContribProjects.Any())
+        {
+            <strong>Package Contributions</strong>
+            <em>You are flagged as a contributor on the following projects:</em>
+            foreach (var project in Model.ContribProjects)
+            {
+                @RenderProject(project)
+            }
+        }
+
+        @if (Model.RetiredProjects.Any())
+        {
+            <strong>Retired Packages</strong>
+            <em>You have indicated that there projects are no longer being maintained. They are still visible in searches so that people can read the reason why it has been retired.</em>
+            foreach (var project in Model.RetiredProjects)
+            {
+                @RenderProject(project)
+            }
+        }
+
     </div>
 </div>
 
@@ -31,9 +59,6 @@
             <div class="col-xs-10 col-md-6">
                 <div class="forum-thread-text">
                     <h3><a href="@project.NiceUrl">@project.Name</a></h3>
-                    <p>
-                        <em>@(project.Live ? "This package is published and live for all to see" : "This is a draft package, and can not be found by others")</em>
-                    </p>
                     <p>
                         @project.Description.StripHtmlAndLimit(45) ...
                         <br />

--- a/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
@@ -1,3 +1,4 @@
+@using LibGit2Sharp
 @using OurUmbraco.MarketPlace.Interfaces
 @using OurUmbraco.Project
 @model OurUmbraco.Our.Models.MyProjectsModel
@@ -6,45 +7,87 @@
     <div class="profile-settings-packages packages-content">
         <a href="/member/profile/projects/details?projectId=" class="button green"><i class="icon-Add"></i>Add package</a>
 
-        @if (Model.LiveProjects.Any())
-        {
-            <strong>Active Packages</strong>
-            <em>Active packages are visible to everyone. If a package is no longer actively maintained please flag it as 'retired'.</em>
-            foreach (var project in Model.LiveProjects)
-            {
-                @RenderProject(project)
-            }
-        }
+        <div class="packages-listing">
+            
+            <div>
 
-        @if (Model.DraftProjects.Any())
-        {
-            <strong>Draft Packages</strong>
-            <em>Draft packages are visible only to you, not anyone else.</em>
-            foreach (var project in Model.DraftProjects)
-            {
-                @RenderProject(project)
-            }
-        }
+                <strong>My Packages</strong>
 
-        @if (Model.ContribProjects.Any())
-        {
-            <strong>Package Contributions</strong>
-            <em>You are flagged as a contributor on the following projects:</em>
-            foreach (var project in Model.ContribProjects)
-            {
-                @RenderProject(project)
-            }
-        }
+                <ul class="tabs">
+                    <li class="tab-link current" data-tab="tab-my-active">Active (@Model.MyLiveProjects.Count())</li>
+                    <li class="tab-link" data-tab="tab-my-draft">Draft (@Model.MyDraftProjects.Count())</li>
+                    <li class="tab-link" data-tab="tab-my-retired">Retired (@Model.MyRetiredProjects.Count())</li>
+                </ul>
 
-        @if (Model.RetiredProjects.Any())
-        {
-            <strong>Retired Packages</strong>
-            <em>You have indicated that these projects are no longer being maintained. They are still visible in searches so that people can read the reason why it has been retired.</em>
-            foreach (var project in Model.RetiredProjects)
-            {
-                @RenderProject(project)
-            }
-        }
+                <div id="tab-my-active" class="tab-content current">
+                    <h3>My Active Packages</h3>
+                    <em>Active packages are visible to everyone.</em>
+                    @foreach (var project in Model.MyLiveProjects)
+                    {
+                        @RenderProject(project)
+                    }
+                </div>
+
+                <div id="tab-my-draft" class="tab-content">
+                    <h3>My Draft Packages</h3>
+                    <em>Draft packages are visible only to you (and your team).</em>
+                    @foreach (var project in Model.MyDraftProjects)
+                    {
+                        @RenderProject(project)
+                    }
+                </div>
+
+                <div id="tab-my-retired" class="tab-content">
+                    <h3>My Retired Packages</h3>
+                    <em>Retired packages are still visible in searches so that people can see the reason for its retirement.</em>
+                    @foreach (var project in Model.MyRetiredProjects)
+                    {
+                        @RenderProject(project)
+                    }
+                </div>
+
+            </div>
+            
+            <div>
+
+                <strong>Package Contributions</strong>
+
+                <ul class="tabs">
+                    <li class="tab-link current" data-tab="tab-contrib-active">Active (@Model.ContribLiveProjects.Count())</li>
+                    <li class="tab-link" data-tab="tab-contrib-draft">Draft (@Model.ContribDraftProjects.Count())</li>
+                    <li class="tab-link" data-tab="tab-contrib-retired">Retired (@Model.ContribRetiredProjects.Count())</li>
+                </ul>
+
+                <div id="tab-contrib-active" class="tab-content current">
+                    <h3>Active Package Contributions</h3>
+                    <em>Active packages are visible to everyone.</em>
+                    @foreach (var project in Model.ContribLiveProjects)
+                    {
+                        @RenderProject(project)
+                    }
+                </div>
+
+                <div id="tab-contrib-draft" class="tab-content">
+                    <h3>Draft Package Contributions</h3>
+                    <em>Draft packages are visible only to the owner and the team.</em>
+                    @foreach (var project in Model.ContribDraftProjects)
+                    {
+                        @RenderProject(project)
+                    }
+                </div>
+
+                <div id="tab-contrib-retired" class="tab-content">
+                    <h3>Retired Package Contributions</h3>
+                    <em>Retired packages are still visible in searches so that people can see the reason for its retirement.</em>
+                    @foreach (var project in Model.ContribRetiredProjects)
+                    {
+                        @RenderProject(project)
+                    }
+                </div>
+
+            </div>
+
+        </div>
 
     </div>
 </div>

--- a/OurUmbraco/Our/Controllers/ProjectsController.cs
+++ b/OurUmbraco/Our/Controllers/ProjectsController.cs
@@ -16,12 +16,15 @@ namespace OurUmbraco.Our.Controllers
 
             var myProjects = nodeListingProvider.GetListingsByVendor(memberId, false, true).OrderBy(x => x.Name);
             var contribProjects = nodeListingProvider.GetListingsForContributor(memberId).OrderBy(x => x.Name);
+            
             var model = new MyProjectsModel
             {
-                LiveProjects = myProjects.Where(project => project.Live && !project.IsRetired),
-                RetiredProjects = myProjects.Where(project => project.Live && project.IsRetired),
-                DraftProjects = myProjects.Where(project => !project.Live),
-                ContribProjects = contribProjects
+                MyLiveProjects = myProjects.Where(project => project.Live && !project.IsRetired),
+                MyRetiredProjects = myProjects.Where(project => project.Live && project.IsRetired),
+                MyDraftProjects = myProjects.Where(project => !project.Live),
+                ContribLiveProjects = contribProjects.Where(project => project.Live && !project.IsRetired),
+                ContribRetiredProjects = contribProjects.Where(project => project.Live && project.IsRetired),
+                ContribDraftProjects = contribProjects.Where(project => !project.Live),
             };
 
             return PartialView("~/Views/Partials/Projects/MyProjects.cshtml", model);

--- a/OurUmbraco/Our/Controllers/ProjectsController.cs
+++ b/OurUmbraco/Our/Controllers/ProjectsController.cs
@@ -18,7 +18,9 @@ namespace OurUmbraco.Our.Controllers
             var contribProjects = nodeListingProvider.GetListingsForContributor(memberId).OrderBy(x => x.Name);
             var model = new MyProjectsModel
             {
-                Projects = myProjects,
+                LiveProjects = myProjects.Where(project => project.Live && !project.IsRetired),
+                RetiredProjects = myProjects.Where(project => project.Live && project.IsRetired),
+                DraftProjects = myProjects.Where(project => !project.Live),
                 ContribProjects = contribProjects
             };
 

--- a/OurUmbraco/Our/Models/MyProjectsModel.cs
+++ b/OurUmbraco/Our/Models/MyProjectsModel.cs
@@ -5,9 +5,11 @@ namespace OurUmbraco.Our.Models
 {
     public class MyProjectsModel
     {
-        public IEnumerable<IListingItem> LiveProjects { get; set; }
-        public IEnumerable<IListingItem> RetiredProjects { get; set; }
-        public IEnumerable<IListingItem> DraftProjects { get; set; }
-        public IEnumerable<IListingItem> ContribProjects { get; set; }
+        public IEnumerable<IListingItem> MyLiveProjects { get; set; }
+        public IEnumerable<IListingItem> MyRetiredProjects { get; set; }
+        public IEnumerable<IListingItem> MyDraftProjects { get; set; }
+        public IEnumerable<IListingItem> ContribLiveProjects { get; set; }
+        public IEnumerable<IListingItem> ContribRetiredProjects { get; set; }
+        public IEnumerable<IListingItem> ContribDraftProjects { get; set; }
     }
 }

--- a/OurUmbraco/Our/Models/MyProjectsModel.cs
+++ b/OurUmbraco/Our/Models/MyProjectsModel.cs
@@ -5,7 +5,9 @@ namespace OurUmbraco.Our.Models
 {
     public class MyProjectsModel
     {
-        public IEnumerable<IListingItem> Projects { get; set; }
+        public IEnumerable<IListingItem> LiveProjects { get; set; }
+        public IEnumerable<IListingItem> RetiredProjects { get; set; }
+        public IEnumerable<IListingItem> DraftProjects { get; set; }
         public IEnumerable<IListingItem> ContribProjects { get; set; }
     }
 }


### PR DESCRIPTION
This relates to https://github.com/umbraco/Umbraco.Packages/issues/56

Previously all packages were listed in alphabetical order with no indication of their 'status', i.e. whether they were Active, Draft or Retired

This PR now groups members' packages by status, with Active, then Draft, then their Contributions (already a separate listing), followed by 'Retired'. Hopefully this will encourage package developers to retire active packages more often.

For example:

![image](https://user-images.githubusercontent.com/4716542/79044664-42274180-7bfe-11ea-84fe-e9017e2dde38.png)

![image](https://user-images.githubusercontent.com/4716542/79044671-4a7f7c80-7bfe-11ea-9afc-e3e8042cb6d8.png)

![image](https://user-images.githubusercontent.com/4716542/79044676-52d7b780-7bfe-11ea-828a-74296cf00b98.png)

![image](https://user-images.githubusercontent.com/4716542/79044726-bf52b680-7bfe-11ea-8adb-26f1a43550b3.png)


If they have no packages then no headings appear, just the 'add' button:

![image](https://user-images.githubusercontent.com/4716542/79044586-dfce4100-7bfd-11ea-8037-e57bbbab979e.png)
