### PR TITLE
"Upcoming meetups" only show one event per group #532

### DIFF
--- a/OurUmbraco/Community/Meetup/MeetupService.cs
+++ b/OurUmbraco/Community/Meetup/MeetupService.cs
@@ -25,60 +25,67 @@ namespace OurUmbraco.Community.Meetup
     {
         public void UpdateMeetupStats()
         {
-            var configPath = HostingEnvironment.MapPath("~/config/MeetupUmbracoGroups.txt");
-            // Get the alias (urlname) of each group from the config file
-            var aliases = File.ReadAllLines(configPath).Where(x => x.Trim() != "").Distinct().ToArray();
-
-            var counterPath = HostingEnvironment.MapPath("~/App_Data/TEMP/MeetupStatisticsCounter.txt");
-            var counter = 0;
-            if (File.Exists(counterPath))
+            try
             {
-                var savedCounter = File.ReadAllLines(counterPath).First();
-                int.TryParse(savedCounter, out counter);
-            }
+                var configPath = HostingEnvironment.MapPath("~/config/MeetupUmbracoGroups.txt");
+                // Get the alias (urlname) of each group from the config file
+                var aliases = File.ReadAllLines(configPath).Where(x => x.Trim() != "").Distinct().ToArray();
 
-            var newCounter = aliases.Length <= counter ? 0 : counter + 1;
-            File.WriteAllText(counterPath, newCounter.ToString(), Encoding.UTF8);
-
-            var client = new MeetupOAuth2Client();
-            var response = client.DoHttpGetRequest(string.Format("https://api.meetup.com/{0}/events?page=1000&status=past", aliases[counter]));
-            var events = MeetupGetEventsResponse.ParseResponse(response).Body;
-
-            var meetupCache = new List<MeetupCacheItem>();
-            var meetupCacheFile = HostingEnvironment.MapPath("~/App_Data/TEMP/MeetupStatisticsCache.json");
-            if (File.Exists(meetupCacheFile))
-            {
-                var json = File.ReadAllText(meetupCacheFile);
-                using (var stringReader = new StringReader(json))
-                using (var jsonTextReader = new JsonTextReader(stringReader))
+                var counterPath = HostingEnvironment.MapPath("~/App_Data/TEMP/MeetupStatisticsCounter.txt");
+                var counter = 0;
+                if (File.Exists(counterPath))
                 {
-                    var jsonSerializer = new JsonSerializer();
-                    meetupCache = jsonSerializer.Deserialize<List<MeetupCacheItem>>(jsonTextReader);
+                    var savedCounter = File.ReadAllLines(counterPath).First();
+                    int.TryParse(savedCounter, out counter);
                 }
-            }
 
-            foreach (var meetupEvent in events)
-            {
-                if (meetupCache.Any(x => x.Id == meetupEvent.Id))
-                    continue;
+                var newCounter = aliases.Length <= counter ? 0 : counter + 1;
+                File.WriteAllText(counterPath, newCounter.ToString(), Encoding.UTF8);
 
-                var meetupCacheItem = new MeetupCacheItem
+                var client = new MeetupOAuth2Client();
+                var response = client.DoHttpGetRequest(string.Format("https://api.meetup.com/{0}/events?page=1000&status=past", aliases[counter]));
+                var events = MeetupGetEventsResponse.ParseResponse(response).Body;
+
+                var meetupCache = new List<MeetupCacheItem>();
+                var meetupCacheFile = HostingEnvironment.MapPath("~/App_Data/TEMP/MeetupStatisticsCache.json");
+                if (File.Exists(meetupCacheFile))
                 {
-                    Time = meetupEvent.Time,
-                    Created = meetupEvent.Created,
-                    Description = meetupEvent.Description,
-                    HasVenue = meetupEvent.HasVenue,
-                    Id = meetupEvent.Id,
-                    Link = meetupEvent.Link,
-                    Name = meetupEvent.Name,
-                    Updated = meetupEvent.Updated,
-                    Visibility = meetupEvent.Visibility
-                };
-                meetupCache.Add(meetupCacheItem);
-            }
+                    var json = File.ReadAllText(meetupCacheFile);
+                    using (var stringReader = new StringReader(json))
+                    using (var jsonTextReader = new JsonTextReader(stringReader))
+                    {
+                        var jsonSerializer = new JsonSerializer();
+                        meetupCache = jsonSerializer.Deserialize<List<MeetupCacheItem>>(jsonTextReader);
+                    }
+                }
 
-            var rawJson = JsonConvert.SerializeObject(meetupCache, Formatting.Indented);
-            File.WriteAllText(meetupCacheFile, rawJson, Encoding.UTF8);
+                foreach (var meetupEvent in events)
+                {
+                    if (meetupCache.Any(x => x.Id == meetupEvent.Id))
+                        continue;
+
+                    var meetupCacheItem = new MeetupCacheItem
+                    {
+                        Time = meetupEvent.Time,
+                        Created = meetupEvent.Created,
+                        Description = meetupEvent.Description,
+                        HasVenue = meetupEvent.HasVenue,
+                        Id = meetupEvent.Id,
+                        Link = meetupEvent.Link,
+                        Name = meetupEvent.Name,
+                        Updated = meetupEvent.Updated,
+                        Visibility = meetupEvent.Visibility
+                    };
+                    meetupCache.Add(meetupCacheItem);
+                }
+
+                var rawJson = JsonConvert.SerializeObject(meetupCache, Formatting.Indented);
+                File.WriteAllText(meetupCacheFile, rawJson, Encoding.UTF8);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<MeetupsController>("Could not get events from meetup.com", ex);
+            }
         }
 
 
@@ -95,6 +102,7 @@ namespace OurUmbraco.Community.Meetup
                 if (File.Exists(configPath) == false)
                 {
                     LogHelper.Debug<MeetupsController>("Config file was not found: " + configPath);
+
                     return meetups;
                 }
 
@@ -106,7 +114,6 @@ namespace OurUmbraco.Community.Meetup
                     {
                         // Initialize a new service instance (we don't specify an API key since we're accessing public data) 
                         var service = new Skybrud.Social.Meetup.MeetupService();
-
                         var items = new List<MeetupItem>();
 
                         foreach (var alias in aliases)
@@ -119,17 +126,19 @@ namespace OurUmbraco.Community.Meetup
                                 if (meetupGroup.JObject.HasValue("next_event") == false)
                                     continue;
 
-                                var nextEventId = meetupGroup.JObject.GetString("next_event.id");
-
                                 // Make the call to the Meetup.com API to get upcoming events
                                 var events = service.Events.GetEvents(alias);
 
-                                // Get the next event(s)
-                                var nextEvent = events.Body.FirstOrDefault(x => x.Id == nextEventId);
+                                // Get the events in the next 30 days
+                                var nextEvents = events.Body.Where(x => x.Time < DateTime.Now.AddDays(30) );
 
-                                // Append the first event of the group
-                                if (nextEvent != null)
-                                    items.Add(new MeetupItem(meetupGroup, nextEvent));
+                                if (nextEvents.Any())
+                                {
+                                    foreach (var item in nextEvents)
+                                    {
+                                        items.Add(new MeetupItem(meetupGroup, item));
+                                    }
+                                }
                             }
                             catch (Exception ex)
                             {

--- a/OurUmbraco/Community/Meetup/MeetupService.cs
+++ b/OurUmbraco/Community/Meetup/MeetupService.cs
@@ -148,7 +148,7 @@ namespace OurUmbraco.Community.Meetup
 
                         return items.OrderBy(x => x.Event.Time).ToArray();
 
-                    }, TimeSpan.FromMinutes(30));
+                    }, TimeSpan.FromMinutes(60));
             }
             catch (Exception ex)
             {

--- a/OurUmbraco/Community/Twitter/TwitterService.cs
+++ b/OurUmbraco/Community/Twitter/TwitterService.cs
@@ -45,7 +45,7 @@ namespace OurUmbraco.Community.Twitter
                             };
 
                             var results = service.Search(options);
-                            return results.Statuses;
+                            return results?.Statuses;
 
                         }, TimeSpan.FromMinutes(2));
 

--- a/OurUmbraco/Community/Videos/CommunityVideosService.cs
+++ b/OurUmbraco/Community/Videos/CommunityVideosService.cs
@@ -96,103 +96,111 @@ namespace OurUmbraco.Community.Videos
 
         public void UpdateYouTubePlaylistVideo(string playlistId)
         {
-
-            // Make sure we have a TEMP directory
-            string dir = IOHelper.MapPath("~/App_Data/TEMP/YouTube/");
-            Directory.CreateDirectory(dir);
-
-            // Make an initial request to get information about the playlist
-            var response1 = Api.YouTube.Playlists.GetPlaylists(new YouTubeGetPlaylistListOptions
+            try
             {
-                Ids = new[] { playlistId }
-            });
+                // Make sure we have a TEMP directory
+                string dir = IOHelper.MapPath("~/App_Data/TEMP/YouTube/");
+                Directory.CreateDirectory(dir);
 
-            // Get a reference to the playlist (using "Single" as there should be exactly one playlist)
-            var playlist = response1.Body.Items.Single();
-
-            // Save the playlist to the disk
-            JsonUtils.SaveJsonObject(dir + "Playlist_" + playlist.Id + ".json", playlist);
-
-            // List of all video IDs
-            List<string> ids = new List<string>();
-
-            // Initialize the options for getting the playlist items
-            var playlistItemsOptions = new YouTubeGetPlaylistItemListOptions(playlistId)
-            {
-
-                // Maximum allowed value is 50
-                MaxResults = 50
-
-            };
-
-            int page = 0;
-            while (page < 10)
-            {
-
-                // Get the playlist items
-                var response2 = Api.YouTube.PlaylistItems.GetPlaylistItems(playlistItemsOptions);
-
-                // Append each video ID to the list
-                foreach (var item in response2.Body.Items)
+                // Make an initial request to get information about the playlist
+                var response1 = Api.YouTube.Playlists.GetPlaylists(new YouTubeGetPlaylistListOptions
                 {
-                    ids.Add(item.VideoId);
-                }
+                    Ids = new[] {playlistId}
+                });
 
-                // Break the loop if there are no additional pages
-                if (String.IsNullOrWhiteSpace(response2.Body.NextPageToken))
+                // Get a reference to the playlist (using "Single" as there should be exactly one playlist)
+                var playlist = response1.Body.Items.Single();
+
+                // Save the playlist to the disk
+                JsonUtils.SaveJsonObject(dir + "Playlist_" + playlist.Id + ".json", playlist);
+
+                // List of all video IDs
+                List<string> ids = new List<string>();
+
+                // Initialize the options for getting the playlist items
+                var playlistItemsOptions = new YouTubeGetPlaylistItemListOptions(playlistId)
                 {
-                    break;
-                }
 
-                // Update the options with the page token
-                playlistItemsOptions.PageToken = response2.Body.NextPageToken;
+                    // Maximum allowed value is 50
+                    MaxResults = 50
 
-                page++;
-
-            }
-
-            // Iterate through groups of IDs (maximum 50 items per group)
-            foreach (var group in ids.Where(x => !ExistsOnDiskAndIsUpToDate(x)).InGroupsOf(50))
-            {
-
-                // Initialize the video options
-                var videosOptions = new YouTubeGetVideoListOptions
-                {
-                    Ids = group.ToArray(),
-                    Part = YouTubeVideoParts.Snippet + YouTubeVideoParts.ContentDetails + YouTubeVideoParts.Statistics
                 };
 
-                // Make a request to the APi to get video information
-                var res3 = Api.YouTube.Videos.GetVideos(videosOptions);
-
-                // Iterate through the videos
-                foreach (var video in res3.Body.Items)
+                int page = 0;
+                while (page < 10)
                 {
 
-                    // Save the video to the disk
-                    string path = dir + "Video_" + video.Id + ".json";
-                    JsonUtils.SaveJsonObject(path, video);
+                    // Get the playlist items
+                    var response2 = Api.YouTube.PlaylistItems.GetPlaylistItems(playlistItemsOptions);
 
-                    // Download the thumnails for each video
-                    var thumbnailUrl = GetThumbnail(video).Url;
+                    // Append each video ID to the list
+                    foreach (var item in response2.Body.Items)
+                    {
+                        ids.Add(item.VideoId);
+                    }
 
-                    const string mediaRoot = "~/media/YouTube";
-                    var thumbnailFile = IOHelper.MapPath($"{mediaRoot}/{video.Id}.jpg");
+                    // Break the loop if there are no additional pages
+                    if (String.IsNullOrWhiteSpace(response2.Body.NextPageToken))
+                    {
+                        break;
+                    }
 
-                    var mediaPath = IOHelper.MapPath(mediaRoot);
-                    if (Directory.Exists(mediaPath) == false)
-                        Directory.CreateDirectory(mediaPath);
+                    // Update the options with the page token
+                    playlistItemsOptions.PageToken = response2.Body.NextPageToken;
 
-                    if (File.Exists(thumbnailFile))
-                        continue;
+                    page++;
 
-                    using (var client = new WebClient())
-                        client.DownloadFile(thumbnailUrl, thumbnailFile);
                 }
-            }
 
-            // Load the videos from the individual files, and save them to a common file
-            JsonUtils.SaveJsonArray(dir + "Playlist_" + playlistId + "_Videos.json", ids.Select(LoadYouTubeVideo).WhereNotNull());
+                // Iterate through groups of IDs (maximum 50 items per group)
+                foreach (var group in ids.Where(x => !ExistsOnDiskAndIsUpToDate(x)).InGroupsOf(50))
+                {
+
+                    // Initialize the video options
+                    var videosOptions = new YouTubeGetVideoListOptions
+                    {
+                        Ids = group.ToArray(),
+                        Part = YouTubeVideoParts.Snippet + YouTubeVideoParts.ContentDetails +
+                               YouTubeVideoParts.Statistics
+                    };
+
+                    // Make a request to the APi to get video information
+                    var res3 = Api.YouTube.Videos.GetVideos(videosOptions);
+
+                    // Iterate through the videos
+                    foreach (var video in res3.Body.Items)
+                    {
+
+                        // Save the video to the disk
+                        string path = dir + "Video_" + video.Id + ".json";
+                        JsonUtils.SaveJsonObject(path, video);
+
+                        // Download the thumnails for each video
+                        var thumbnailUrl = GetThumbnail(video).Url;
+
+                        const string mediaRoot = "~/media/YouTube";
+                        var thumbnailFile = IOHelper.MapPath($"{mediaRoot}/{video.Id}.jpg");
+
+                        var mediaPath = IOHelper.MapPath(mediaRoot);
+                        if (Directory.Exists(mediaPath) == false)
+                            Directory.CreateDirectory(mediaPath);
+
+                        if (File.Exists(thumbnailFile))
+                            continue;
+
+                        using (var client = new WebClient())
+                            client.DownloadFile(thumbnailUrl, thumbnailFile);
+                    }
+                }
+
+                // Load the videos from the individual files, and save them to a common file
+                JsonUtils.SaveJsonArray(dir + "Playlist_" + playlistId + "_Videos.json",
+                    ids.Select(LoadYouTubeVideo).WhereNotNull());
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<CommunityVideosService>("Could not get data from YouTube", ex);
+            }
         }
 
         private static YouTubeVideoThumbnail GetThumbnail(YouTubeVideo video)


### PR DESCRIPTION
### Description
Changed the upcoming meetups to return all meetups in the next 30 days.
Also added some try-catch logic around the Twitter, Vimeo and YouTube requests to handle Invalid responses.

### Testing 
Run the site and view the "Upcoming meetups" on the home page. It should display events in the next 30 days, and for some groups there may be more than one.