### PR TITLE
Converted ATOM feed to RSS feed

### DIFF
--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -293,7 +293,7 @@
       "checkTitles": false,
       "title": "My Umbraco Adventures",
       "url": "https://jvantroyen.blogspot.com/",
-      "rss": "http://jvantroyen.blogspot.com/feeds/posts/default",
+      "rss": "https://feeds.feedburner.com/MyUmbracoAdventures",
       "logo": "https://our.umbraco.com/media/upload/0e40926e-0884-42e4-abc4-ed72ab2f2c31/Jeroen%20Vantroyen.png?width=500&height=500&mode=crop&upscale=true",
       "memberId": 274827
     }


### PR DESCRIPTION
See #568. I added my feed last year, but turns out it's an ATOM feed, which is not supported. 
Now converted to RSS using FeedBurner.