### PR TITLE
Improved the look of the buttons on the package list

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_profile.scss
+++ b/OurUmbraco.Client/src/scss/elements/_profile.scss
@@ -427,6 +427,39 @@
 			margin-top: 0 !important;
 		}
 	}
+
+	.list-buttons {
+		display: inline-block;
+		margin-top: 10px;
+		white-space: nowrap;
+		&.category {
+			a {
+				white-space:normal;
+			}
+		}
+		a {
+			font-size: .8rem;
+			text-decoration: none;
+			margin-right: 1px;
+			i {
+				color:#fff;
+				font-size: 0.8rem;
+				margin-right: .2rem;
+			}
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+		@media(min-width:$md) {
+			a{
+				font-size: .9rem;
+				margin-right: 8px;
+				i {
+					font-size: 1.1rem;
+				}
+			}
+		}
+	}
 }
 
 

--- a/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/MyProjects.cshtml
@@ -36,11 +36,18 @@
                     </p>
                     <p>
                         @project.Description.StripHtmlAndLimit(45) ...
-                        <br />
-                        <a href="details?projectId=@project.Id">Edit</a>
-                        <a href="manage-package-forums/?id=@project.Id">Forums</a>
-                        <a href="manage-team/?id=@project.Id">Team</a>
                     </p>
+                    <div class="list-buttons category">
+                        <a href="details?projectId=@project.Id">
+                            <i class="icon-Edit"></i><span>Edit</span>
+                        </a>
+                        <a href="manage-package-forums/?id=@project.Id" class="edit-post">
+                            <i class="icon-Chat"></i><span>Forums</span>
+                        </a>
+                        <a href="manage-team/?id=@project.Id" class="edit-post">
+                            <i class="icon-Users"></i><span>Team</span>
+                        </a>
+                    </div>
                 </div>
             </div>
             <div class="col-xs-12 col-md-5">


### PR DESCRIPTION
A quick refresh of the edit / forum / team buttons on the package list to better go with the rest of the site.

Desktop:

![image](https://user-images.githubusercontent.com/5808078/79915916-c14b1f80-841f-11ea-83f5-20366c6fb851.png)

Mobile:

![image](https://user-images.githubusercontent.com/5808078/79915978-d922a380-841f-11ea-8c98-ebf86431701a.png)
