### PR TITLE
hide category list when in mobile size

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_packages.scss
+++ b/OurUmbraco.Client/src/scss/sections/_packages.scss
@@ -268,6 +268,10 @@ section.packages {
                 }
             }
         }
+
+        @media (max-width: $md) {
+            display: none;
+        }
     }
 
 


### PR DESCRIPTION
closes https://github.com/umbraco/Umbraco.Packages/issues/52

As the categories aren't that useful I've decided to just hide them on mobile rather than to take up the already limited space with them.