### PR TITLE
catch exceptions while indexing yaml meta tags

### DIFF
--- a/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.controller.js
+++ b/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.controller.js
@@ -142,4 +142,21 @@
                 notificationsService.error(vm.memberError);
             });
     };
+
+    $scope.getInvalidDocsArticles = function () {
+        var getInvalidDocsUrl = "backoffice/API/Docs/GetInvalidDocsArticles";
+        $http.get(getInvalidDocsUrl)
+            .success(function (data) {
+                if (data.length === 0) {
+                    vm.invalidDocsArticles = "No articles found with invalid YAML";
+                }
+                else {
+                    vm.invalidDocsArticles = data;
+                }
+            })
+            .error(function () {
+                vm.docsError = "❌ Problem with getting the invalid docs article results.";
+                notificationsService.error(vm.memberError);
+            });
+    };
 });

--- a/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.html
+++ b/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.html
@@ -8,6 +8,13 @@
         <umb-load-indicator ng-if="vm.docsLoading"></umb-load-indicator>
     </p>
 
+    <button type="button" ng-click="getInvalidDocsArticles()">
+        Check invalid YAML
+    </button>
+    <p ng-repeat="invalidDocsArticle in vm.invalidDocsArticles">
+        {{invalidDocsArticle}}<br />
+    </p>
+
     <h3>Members - contrib / profile</h3>
     <p>Here you can search for members to go to them in the members section or to add a contrib badge to their Our profile.<br />
     <p>Search for a member Id or a part of a member's name, email address, twitter profile or github profile</p>

--- a/OurUmbraco/Our/Api/DocsController.cs
+++ b/OurUmbraco/Our/Api/DocsController.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Web.Http;
+using Examine;
+using Umbraco.Web.WebApi;
+
+namespace OurUmbraco.Our.Api
+{
+    public class DocsController : UmbracoAuthorizedApiController
+    {
+        [HttpGet]
+        public List<string> GetInvalidDocsArticles()
+        {
+            var searcher = ExamineManager.Instance.SearchProviderCollection["documentationSearcher"];
+            var criteria = searcher.CreateSearchCriteria();
+            var rawQuery = $"+tags: yamlissue";
+            var query = criteria.RawQuery(rawQuery);
+            var results = searcher.Search(query);
+
+            var articleList = new List<string>();
+
+            foreach (var searchResult in results)
+            {
+                articleList.Add(searchResult["url"]);
+            }
+
+            return articleList;
+        }
+    }
+}

--- a/OurUmbraco/Our/Examine/ExamineHelper.cs
+++ b/OurUmbraco/Our/Examine/ExamineHelper.cs
@@ -11,6 +11,7 @@ using System.Text;
 using YamlDotNet.Serialization;
 using OurUmbraco.Documentation.Busineslogic;
 using System.Configuration;
+using YamlDotNet.Core;
 
 namespace OurUmbraco.Our.Examine
 {
@@ -117,7 +118,7 @@ namespace OurUmbraco.Our.Examine
                 // But first trim all trailing spaces as this only creates issues which are hard to debug
                 // and unclear for users. Make sure you have a ToList because IEnumerable has no IndexOf()
                 secondYamlMarker = lines
-                    .Select(l=>l.TrimEnd())
+                    .Select(l => l.TrimEnd())
                     .ToList()
                     .IndexOf("---", 1);
 
@@ -137,7 +138,15 @@ namespace OurUmbraco.Our.Examine
                         .WithNamingConvention(new YamlDotNet.Serialization.NamingConventions.CamelCaseNamingConvention())
                         .IgnoreUnmatchedProperties()
                         .Build();
-                    yamlMetaData = deserializer.Deserialize<YamlMetaData>(yamlInput.ToString());
+                    try
+                    {
+                        yamlMetaData = deserializer.Deserialize<YamlMetaData>(yamlInput.ToString());
+                    }
+                    catch (SemanticErrorException ex)
+                    {
+                        LogHelper.Error(typeof(ExamineHelper), "Could not parse the YAML meta data {0}" + yamlInput, ex);
+                        yamlMetaData.Tags = "yamlissue";
+                    }
                 }
 
                 // Add Yaml stuff to the LUCENE index

--- a/OurUmbraco/OurUmbraco.csproj
+++ b/OurUmbraco/OurUmbraco.csproj
@@ -488,6 +488,7 @@
     <Compile Include="Location\LocationService.cs" />
     <Compile Include="Location\Models\Location.cs" />
     <Compile Include="Our\Api\DashboardStatisticsController.cs" />
+    <Compile Include="Our\Api\DocsController.cs" />
     <Compile Include="Our\Api\InstallationController.cs" />
     <Compile Include="Our\Api\MembersController.cs" />
     <Compile Include="Our\Api\OurMemberStatisticsController.cs" />


### PR DESCRIPTION
If we don't catch errors and there is a syntax error in the meta tags, indexing will stop and search will not be working again (for documentation) on our.