### PR TITLE
adding umbPack as an umbraco public repo

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -156,6 +156,7 @@ else
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.Contrib" target="_blank"`rel="noreferrer noopener" title="Umbraco.Deploy.Contrib">Umbraco.Deploy.Contrib</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Courier.Contrib" target="_blank" rel="noreferrer noopener" title="Umbraco.Courier.Contrib">Umbraco.Courier.Contrib</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.ValueConnectors" target="_blank" rel="noreferrer noopener" title="Umbraco.Deploy.ValueConnectors">Umbraco.Deploy.ValueConnectors</a>,
+                                <a href="https://github.com/umbraco/UmbPack" target="_blank" rel="noreferrer noopener" title="UmbPack">UmbPack</a>,
                                 <a href="https://github.com/umbraco/rfcs" target="_blank" rel="noreferrer noopener" title="RFCs">RFCs</a>,
                                 <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank" rel="noreferrer noopener" title="The-Starter-Kit">The-Starter-Kit</a> and
                                 <a href="https://github.com/umbraco/organizer-guide" target="_blank" rel="noreferrer noopener" title="organizer-guide">organizer-guide</a> repos

--- a/OurUmbraco.Site/config/GitHubPublicRepositories.json
+++ b/OurUmbraco.Site/config/GitHubPublicRepositories.json
@@ -63,6 +63,12 @@
     "Alias": "Umbraco.Courier.Contrib",
     "Owner": "umbraco",
     "Slug": "Umbraco.Courier.Contrib",
-    "Name": "Umbraco Courier Contrib" 
+    "Name": "Umbraco Courier Contrib"
+  },
+  {
+    "Alias": "UmbPack",
+    "Owner": "umbraco",
+    "Slug": "UmbPack",
+    "Name": "UmbPack"
   }
 ]

--- a/OurUmbraco/Community/GitHub/GitHubService.cs
+++ b/OurUmbraco/Community/GitHub/GitHubService.cs
@@ -302,7 +302,8 @@ namespace OurUmbraco.Community.GitHub
                 "OurUmbraco",
                 "Umbraco.Courier.Contrib",
                 "Umbraco.Deploy.Contrib",
-                "Umbraco.Deploy.ValueConnectors" ,
+                "Umbraco.Deploy.ValueConnectors",
+                "UmbPack",
                 "rfcs",	
                 "organizer-guide",
                 "The-Starter-Kit"


### PR DESCRIPTION
I believe this is what is required to get the PRs to the UmbPack repo included in the contributions list on the Our home page.  Seeing the repository name in the list may encourage people to have a look to see if they can contribute!