### PR TITLE
Added styling for new links box

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
+++ b/OurUmbraco.Client/src/scss/elements/_markdown-syntax.scss
@@ -538,3 +538,89 @@
     }
 
 }
+
+
+.markdown-syntax .center {
+    text-align: center;
+}
+
+.markdown-syntax .links {
+    background: #3544B0;
+    margin: 30px 0;
+    padding: 50px;
+
+    ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    ul > li {
+        margin: 0;
+        padding: 7px 0 0 48px;
+        position: relative;
+    }
+
+    ul > li > a {
+        font-weight: normal;
+    }
+
+    ul > li:before {
+        background: #3544B0;
+        display: block;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        color: #fff;
+        left: 0;
+        top: 0;
+        position: absolute;
+        line-height: 32px;
+        font-size: 16px;
+        text-align: center;
+        content: "\e247";
+        font-family: icomoon;
+    }
+
+    ul > li + li {
+        margin-top: 25px;
+    }
+
+    h2, h3, h4 {
+        color: #fff;
+        margin: -10px 0 25px 0;
+        font-size: 25px;
+        font-weight: normal;
+    }
+
+    ul > li:before {
+        background: #fff;
+        color: #3544B0;
+    }
+}
+
+#markdown-docs .links {
+
+    ul {
+
+        li {
+
+            a {
+                color: #fff;
+                text-decoration: none;
+                font-weight: normal;
+
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+
+            code {
+                background: rgba(0,0,0,0.25);
+            }
+        
+        }
+    
+    }
+
+}


### PR DESCRIPTION
As part of https://github.com/umbraco/UmbracoDocs/issues/2045, I suggested a new blue box for links, which given the blue color would be easier to see than a regular list of links. Sorta like the *call to action* links we typically make for our client's websites.

Per @jmayntzhusen's suggestion, you can then write something like:

```
:::links
### I can has links?
- [`<umbLoadIndicator />` in the **API documentation**](/apidocs/v8/ui/#/api/umbraco.directives.directive:umbLoadIndicator)
- [`<umbLoadIndicator />` source code on **GitHub**](https://github.com/umbraco/Umbraco-CMS/blob/v8/contrib/src/Umbraco.Web.UI.Client/src/common/directives/components/umbloadindicator.directive.js)
:::
```

Technically you can add anything as the content of the box, but I've only added styling for an unordered list - and an optional title for the box (H2, H3 or H4 given what fits the article structure - they are styled the same).

The result of my example snippet is:

![image](https://user-images.githubusercontent.com/3634580/82951042-c2371a00-9fa6-11ea-902e-de15eae9b76f.png)

For the article I'm working on, there is a small GIF that takes a bit more than half of the main column. IMO it looks a bit silly to be left aligned, so I've also added styling so you can write:

```
:::center
![Example of the load indicator](umbLoadIndicator.gif)
:::
```

Result:

![image](https://user-images.githubusercontent.com/3634580/82951198-062a1f00-9fa7-11ea-9959-2f31b557a298.png)

I hope this is okay to include in this PR since it's just a single line 😉 
