### PR TITLE
Grabs pkg version from form and updates the content node accordingly

### DIFF
--- a/OurUmbraco/Project/Api/ProjectUploadController.cs
+++ b/OurUmbraco/Project/Api/ProjectUploadController.cs
@@ -67,6 +67,7 @@ namespace OurUmbraco.Project.Api
                     var dotNetVersion = provider.FormData["dotNetVersion"];
                     var umbracoVersions = JsonConvert.DeserializeObject<List<UmbracoVersion>>(provider.FormData["umbracoVersions"]);
                     var isCurrent = bool.Parse(provider.FormData["isCurrent"]);
+                    var packageVersionNumber = provider.FormData["packageVersion"];
 
                     var contentService = ApplicationContext.Services.ContentService;
 
@@ -94,8 +95,8 @@ namespace OurUmbraco.Project.Api
                             packageEntity.SetValue("file", file.Id);
 
                         packageEntity.SetValue("dotNetVersion", dotNetVersion);
+                        packageEntity.SetValue("version", packageVersionNumber);
 
-                       
 
                         contentService.SaveAndPublishWithStatus(packageEntity);
 

--- a/OurUmbraco/Project/Api/ProjectUploadController.cs
+++ b/OurUmbraco/Project/Api/ProjectUploadController.cs
@@ -90,14 +90,14 @@ namespace OurUmbraco.Project.Api
                         );
 
                         file.Current = isCurrent;
-                        
+
                         if (isCurrent)
+                        {
                             packageEntity.SetValue("file", file.Id);
+                            packageEntity.SetValue("version", packageVersionNumber);
+                        }
 
                         packageEntity.SetValue("dotNetVersion", dotNetVersion);
-                        packageEntity.SetValue("version", packageVersionNumber);
-
-
                         contentService.SaveAndPublishWithStatus(packageEntity);
 
                         DeleteTempFile(packageFile);


### PR DESCRIPTION
This is conjunction with https://github.com/umbraco/UmbPack/pull/27 will ensure that a new package pushed via UmbPack will update the current version to whatever the package file has set in its package.xml:

![pkgVersion](https://user-images.githubusercontent.com/36075913/85297347-eb15d680-b4a2-11ea-96e8-73b0bd455d7a.gif)
