### PR TITLE
fixes required to rebuild 'projectIndexer' with new dev db

### DIFF
--- a/OurUmbraco/Our/Examine/ProjectNodeIndexDataService.cs
+++ b/OurUmbraco/Our/Examine/ProjectNodeIndexDataService.cs
@@ -140,7 +140,11 @@ namespace OurUmbraco.Our.Examine
             var allProjectDownloads = Utils.GetProjectTotalPackageDownload();
             var allCompatVersions = Utils.GetProjectCompatibleVersions();
             var mostRecentDownloadDate = WikiFile.GetMostRecentDownloadDate();
-            var downloadStats = WikiFile.GetMonthlyDownloadStatsByProject(mostRecentDownloadDate.Subtract(TimeSpan.FromDays(365)));            
+
+            // if most recent download date is MinValue then there is no download data to query
+            var downloadStats = mostRecentDownloadDate == DateTime.MinValue
+                ? new Dictionary<int, MonthlyProjectDownloads>()
+                : WikiFile.GetMonthlyDownloadStatsByProject(mostRecentDownloadDate.Subtract(TimeSpan.FromDays(365)));
 
             foreach (var project in projects)
             {

--- a/OurUmbraco/Wiki/BusinessLogic/WikiFile.cs
+++ b/OurUmbraco/Wiki/BusinessLogic/WikiFile.cs
@@ -117,7 +117,7 @@ WHERE timestamp > @from";
                         Path = result.path,
                         Name = result.name,
                         FileType = result.type,
-                        RemovedBy = result.removedBy,
+                        RemovedBy = result.removedBy ?? 0,
                         CreatedBy = result.createdBy,
                         NodeVersion = result.version,
                         NodeId = result.nodeId,


### PR DESCRIPTION
Using the new dev db, rebuilding 'projectIndexer' returned 0 documents for me because of two errors.

### Error 1
As there is no data in the ```projectDownload``` table, the most recent download date returned is ```DateTime.MinValue```.  The code then falls over when trying to subtract 365 days from the returned date (of course can't have a date earlier than MinValue). This will only be an issue when using the new db. This PR changes it to not query the db and just return empty collection in this instance.

### Error 2
The other error was that the database was returning NULL for the ```removedBy``` column for the one record in the ```wikiFiles``` table, and the ```RemovedBy``` property of the ```WikiFile``` class is a *non-nullable* int.  I've implemented a workaround so am now able to get the index rebuilt and can see the 2 packages on the front-end 🎉.  Not obvious to me why this would only cause a problem with this new db as surely lots of live ```wikiFiles``` records would have null ```removedBy``` properties...