### PR TITLE
Calculates the nuget downloads for 6 months (not days) as per comment

### DIFF
--- a/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
+++ b/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
@@ -105,7 +105,7 @@ namespace OurUmbraco.Our.Examine
 
             if (_dailyNugetDownLoads.HasValue)
             {
-                nugetDownloads = (_dailyNugetDownLoads.Value * (int)((_now - _now.AddDays(-6)).TotalDays));               
+                nugetDownloads = (_dailyNugetDownLoads.Value * (int)((_now - _now.AddMonths(-6)).TotalDays));               
             }
 
             score += nugetDownloads;


### PR DESCRIPTION
Comment in code says `// add the nuget downloads for the last 6 months` but actually it was only doing it for the last 6 days. 

updated to work it out for last 6 months. *(also want to confirm my re naming of branches works)*
