### PR TITLE
fixes #66 - Next button shows on last page of search

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -58,7 +58,7 @@
             <a class="@Umbraco.If(i == page, "active")" href="?page=@i&@url">@i</a>
         }
 
-        @if (page < results.Total)
+        @if (page < results.Pages)
         {
             <span>&hellip;</span>
             <a class="next" href="?page=@(page + 1)&@url">Next</a>


### PR DESCRIPTION
stops the next button appearing at the end of the search pagination when you reach the last page.