### PR TITLE
Fix #619 - Nuget Package download scores.

### DIFF
--- a/OurUmbraco/Community/Nuget/NugetPackageDownloadService.cs
+++ b/OurUmbraco/Community/Nuget/NugetPackageDownloadService.cs
@@ -164,7 +164,7 @@
                     // workout the oldest date based on commit time stamp (when the package was uploaded not published)
                     var date = item.Items
                         .Select(x => new[] { 
-                            x.CommitTimeStamp , 
+                            x.CommitTimeStamp > blankDate ? x.CommitTimeStamp : DateTime.Now, 
                             x.CatalogEntry.PublishedDate > blankDate ? x.CatalogEntry.PublishedDate : DateTime.Now }.Min())
                         .OrderBy(x => x)
                         .FirstOrDefault();

--- a/OurUmbraco/Community/Nuget/NugetPackageDownloadService.cs
+++ b/OurUmbraco/Community/Nuget/NugetPackageDownloadService.cs
@@ -212,7 +212,7 @@
                 if (!Directory.Exists(this._storageDirectory))
                     Directory.CreateDirectory(this._storageDirectory);
 
-                var file = Path.Combine(_storageDirectory, $"{DateTime.Now:yyyyMMdd_HHmmss}_{_downloadsFile}");
+                var file = Path.Combine(_storageDirectory.EnsureEndsWith(Path.DirectorySeparatorChar), _downloadsFile);
 
                 var json = JsonConvert.SerializeObject(packages);
                 File.WriteAllText(file, json, Encoding.UTF8);

--- a/OurUmbraco/Community/Nuget/NugetPackageDownloadService.cs
+++ b/OurUmbraco/Community/Nuget/NugetPackageDownloadService.cs
@@ -181,7 +181,8 @@
             {
                 TotalDownLoads = nugetPackage.TotalDownloads,
                 PackageId = nugetPackage.Id,
-                AverageDownloadPerDay = GetAvarageDownloadsPerDay(nugetPackage.TotalDownloads, oldestDate)
+                AverageDownloadPerDay = GetAvarageDownloadsPerDay(nugetPackage.TotalDownloads, oldestDate),
+                PackageDate = oldestDate
             };
         }
 
@@ -217,7 +218,7 @@
 
                 var file = Path.Combine(_storageDirectory.EnsureEndsWith(Path.DirectorySeparatorChar), _downloadsFile);
 
-                var json = JsonConvert.SerializeObject(packages);
+                var json = JsonConvert.SerializeObject(packages, Formatting.Indented);
                 File.WriteAllText(file, json, Encoding.UTF8);
             }
         }

--- a/OurUmbraco/Community/Nuget/NugetPackageInfo.cs
+++ b/OurUmbraco/Community/Nuget/NugetPackageInfo.cs
@@ -1,5 +1,7 @@
 ﻿namespace OurUmbraco.Community.Nuget
 {
+    using System;
+
     using Newtonsoft.Json;
 
     public class NugetPackageInfo
@@ -9,5 +11,7 @@
         public int TotalDownLoads { get; set; }
 
         public int AverageDownloadPerDay { get; set; }
+
+        public DateTime PackageDate { get; set; }
     }
 }

--- a/OurUmbraco/Community/Nuget/NugetRegistrationCatalogEntry.cs
+++ b/OurUmbraco/Community/Nuget/NugetRegistrationCatalogEntry.cs
@@ -3,10 +3,12 @@
     using System;
 
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
 
     public class NugetRegistrationCatalogEntry
     {
         [JsonProperty("published")]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTime PublishedDate { get; set; }
     }
 }

--- a/OurUmbraco/Community/Nuget/NugetRegistrationItemEntry.cs
+++ b/OurUmbraco/Community/Nuget/NugetRegistrationItemEntry.cs
@@ -1,10 +1,16 @@
 ﻿namespace OurUmbraco.Community.Nuget
 {
+    using System;
+
     using Newtonsoft.Json;
 
     public class NugetRegistrationItemEntry
     {
         [JsonProperty("catalogEntry")]
         public NugetRegistrationCatalogEntry CatalogEntry { get; set; }
+
+        [JsonProperty("commitTimeStamp")]
+        public DateTime CommitTimeStamp { get; set; }
+
     }
 }

--- a/OurUmbraco/Community/Nuget/NugetRegistrationItemEntry.cs
+++ b/OurUmbraco/Community/Nuget/NugetRegistrationItemEntry.cs
@@ -3,6 +3,7 @@
     using System;
 
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
 
     public class NugetRegistrationItemEntry
     {
@@ -10,6 +11,7 @@
         public NugetRegistrationCatalogEntry CatalogEntry { get; set; }
 
         [JsonProperty("commitTimeStamp")]
+        [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTime CommitTimeStamp { get; set; }
 
     }

--- a/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
+++ b/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
@@ -105,7 +105,10 @@ namespace OurUmbraco.Our.Examine
 
             if (_dailyNugetDownLoads.HasValue)
             {
-                nugetDownloads = (_dailyNugetDownLoads.Value * (int)((_now - _now.AddMonths(-6)).TotalDays));               
+                // if the project is younger than 6 months, we count average * age)
+                var days = Math.Min((_now - _now.AddMonths(6)).TotalDays, (_now - _createDate).TotalDays);
+
+                nugetDownloads = (_dailyNugetDownLoads.Value * (int)days);               
             }
 
             score += nugetDownloads;

--- a/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
+++ b/OurUmbraco/Our/Examine/ProjectPopularityPoints.cs
@@ -105,8 +105,11 @@ namespace OurUmbraco.Our.Examine
 
             if (_dailyNugetDownLoads.HasValue)
             {
-                // if the project is younger than 6 months, we count average * age)
-                var days = Math.Min((_now - _now.AddMonths(6)).TotalDays, (_now - _createDate).TotalDays);
+                // some confusion '_now' is not now, its the last update time of the package.
+                // we want to calculate from today. 
+                var today = DateTime.Now;
+
+                var days = Math.Min((today - today.AddMonths(-6)).TotalDays, (today - _createDate).TotalDays);
 
                 nugetDownloads = (_dailyNugetDownLoads.Value * (int)days);               
             }


### PR DESCRIPTION
Fix for the nuget scores 

 - tidied up NugetPackageDownload Service 
 - use the CommitDate not the PublishedDate
 - calculate 6 month downloads for nuget from either 6 months or package create date (whichever is smaller). 

(will need testing with the real data)