### PR TITLE
611 Cannot publish package if I don't enter the full NuGet URL

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Project/Edit.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Project/Edit.cshtml
@@ -112,6 +112,7 @@
                     @Html.LabelFor(m => m.NuGetPackageUrl)
                     @Html.TextBoxFor(m => m.NuGetPackageUrl)
                     @Html.ValidationMessageFor(m => m.NuGetPackageUrl)
+                    <br />
                     <small>url to the NuGet package if any available</small>
                 </p>
                 <p>

--- a/OurUmbraco/Our/Models/ProjectDetails.cs
+++ b/OurUmbraco/Our/Models/ProjectDetails.cs
@@ -44,6 +44,7 @@ namespace OurUmbraco.Our.Models
         public string SourceCodeUrl { get; set; }
 
         [Display(Name = "NuGet package URL")]
+        [RegularExpression("^(?:https?:\\/\\/)?(?:[^.]+\\.)?nuget\\.org(\\/.*)?$", ErrorMessage = "Please enter the full NuGet url")]
         public string NuGetPackageUrl { get; set; }
 
         [Display(Name = "Bug tracking URL")]


### PR DESCRIPTION
Added regex model validation to check if the entered string contains nuget.org

Fixes: #611 