### PR TITLE
Grant member karma

### DIFF
--- a/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.controller.js
+++ b/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.controller.js
@@ -143,6 +143,23 @@
             });
     };
 
+    $scope.addKarmaToMember = function (memberId) {
+        var getKarmaGrantingUrl = "backoffice/API/Members/GrantKarmaForPackageUpload/?memberId=" + memberId;
+        $http.get(getKarmaGrantingUrl)
+            .success(function (data) {
+                if (data === "true") {
+                    vm.addBadgeMessage = "✔ " + vm.memberName + " now has enough karma to create a package.";
+                    notificationsService.success(vm.addBadgeMessage);
+                } else {
+                    notificationsService.error("❌ Problem with adding karma to the member.");
+                }
+            })
+            .error(function () {
+                vm.memberError = "❌ Problem with getting the member.";
+                notificationsService.error(vm.memberError);
+            });
+    };
+
     $scope.getInvalidDocsArticles = function () {
         var getInvalidDocsUrl = "backoffice/API/Docs/GetInvalidDocsArticles";
         $http.get(getInvalidDocsUrl)

--- a/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.html
+++ b/OurUmbraco.Site/App_Plugins/OurManagement/ourmanagement.html
@@ -37,6 +37,10 @@
             Add contrib badge to {{vm.memberName}}
         </button>
         <br />
+        <button type="button" ng-click="addKarmaToMember(vm.memberId)">
+            Add karma to {{vm.memberName}}
+        </button>
+        <br />
     <p ng-if="vm.addBadgeMessage">{{vm.addBadgeMessage}}</p>
     </p>
 

--- a/OurUmbraco/Our/Api/MembersController.cs
+++ b/OurUmbraco/Our/Api/MembersController.cs
@@ -56,6 +56,8 @@ namespace OurUmbraco.Our.Api
                 return false;
 
             member.SetValue("reputationTotal", 31);
+            memberService.Save(member);
+            
             return true;
         }
     }

--- a/OurUmbraco/Our/Api/MembersController.cs
+++ b/OurUmbraco/Our/Api/MembersController.cs
@@ -46,5 +46,17 @@ namespace OurUmbraco.Our.Api
             memberService.AssignRole(member.Id, "CoreContrib");
             return true;
         }
+        
+        [System.Web.Http.HttpGet]
+        public bool GrantKarmaForPackageUpload (int memberId)
+        {
+            var memberService = ApplicationContext.Services.MemberService;
+            var member = memberService.GetById(memberId);
+            if (member == null)
+                return false;
+
+            member.SetValue("reputationTotal", 31);
+            return true;
+        }
     }
 }

--- a/OurUmbraco/Our/Api/MembersController.cs
+++ b/OurUmbraco/Our/Api/MembersController.cs
@@ -55,7 +55,8 @@ namespace OurUmbraco.Our.Api
             if (member == null)
                 return false;
 
-            member.SetValue("reputationTotal", 31);
+            member.SetValue("reputationTotal", 71);
+            member.SetValue("reputationCurrent", 71);
             memberService.Save(member);
             
             return true;


### PR DESCRIPTION
This PR will make it possible for me to add enough karma to new users to be able to upload packages.
It uses the existing backoffice dashboard, here is an example 🙂
![grantKarma](https://user-images.githubusercontent.com/36075913/94531646-227fe600-023d-11eb-88cc-ef2bde6149d5.gif)

Main question I have is whether we should set both the total and current rep points? Not sure what the difference between them is, all I know is the total rep points need to be above 30 for the package upload part.

