### PR TITLE
add templates for bug and feature request, plus a link to the packages repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug.md
@@ -1,0 +1,16 @@
+---
+name: Bug
+about: Use this issue type if you've discovered a problem on the Our website. If it relates to packages please see the note below.
+labels: type/bug
+---
+
+<!-- 
+Please fill in a brief description of the issue here.
+-->
+
+## Detailed description
+
+<!--
+Describe the issue in detail, including how to reproduce it.
+If appropriate, please include error messages and screenshots.
+-->

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Use this issue type if you want to submit a feature request for the Our website. If it relates to packages please see the note below.
+labels: type/feature
+---
+
+<!-- 
+Please fill in a brief description of the request here.
+-->
+
+## Detailed description
+
+<!--
+Describe the intended feature in detail.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Packages Related?
+      url: https://github.com/umbraco/Umbraco.Packages/issues
+      about: If you want to report a bug or discuss a feature request relating to the packages section of the Our website, please do so over on the Package Team repository.


### PR DESCRIPTION
Having issues templates will, hopefully, encourage people to report package related issues over on the Package Team repository, not here.

I don't think I can test how these are going to look without you merging this!

Kept the templates simple as you suggested @nul800sebastiaan 

Thought I better do this today so you didn't mistake this for my Umbraco Hacktoberfest contribution 😉