### PR TITLE
Track downloads from main download-page

### DIFF
--- a/OurUmbraco.Site/Views/Download.cshtml
+++ b/OurUmbraco.Site/Views/Download.cshtml
@@ -57,7 +57,7 @@
 
                 <p class="large-margin-bottom">
                     Current Version:
-                    <a id="downloadButton" class="download-link" href="@Url.GetReleaseUrl(latestRelease, true)">Download @(latestRelease.FullVersion)</a>
+                    <a id="downloadButton" class="download-link" href="@Url.GetReleaseUrl(latestRelease, true)" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@latestRelease.FullVersion']);">Download @(latestRelease.FullVersion)</a>
                     -  See all <a class="download-link" href="/contribute/releases/">previous releases</a>
                 </p>
 

--- a/OurUmbraco.Site/Views/Download.cshtml
+++ b/OurUmbraco.Site/Views/Download.cshtml
@@ -57,7 +57,7 @@
 
                 <p class="large-margin-bottom">
                     Current Version:
-                    <a id="downloadButton" class="download-link" href="@Url.GetReleaseUrl(latestRelease, true)" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', '@latestRelease.FullVersion']);">Download @(latestRelease.FullVersion)</a>
+                    <a id="downloadButton" class="download-link" href="@Url.GetReleaseUrl(latestRelease, true)" onclick="_gaq.push(['_trackEvent', 'Release', 'Download', 'UmbracoCms.@(latestRelease.FullVersion).zip']);">Download @(latestRelease.FullVersion)</a>
                     -  See all <a class="download-link" href="/contribute/releases/">previous releases</a>
                 </p>
 


### PR DESCRIPTION
We already do this on the individual release-pages. Now we should get more real data. 

This is done blindly, as I'm on my mac today - so please test :-p @nul800sebastiaan 