### PR TITLE
Update link in Our>Profile>Packages

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Projects/MyProjects.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/MyProjects.cshtml
@@ -12,5 +12,5 @@
 }
 else
 {
-    <h2>Sorry, your account is too new to create projects! If you're human, make sure to <a href="https://umbraco.com/about-us/team">get in touch with us</a> to get this restriction lifted.</h2>
+    <h2>Sorry, your account is too new to create projects! If you're human, make sure to <a href="https://umbraco.com/contact-us/">get in touch with us</a> to get this restriction lifted.</h2>
 }

--- a/OurUmbraco/Our/usercontrols/ProjectEditor.ascx
+++ b/OurUmbraco/Our/usercontrols/ProjectEditor.ascx
@@ -1,7 +1,7 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" CodeBehind="ProjectEditor.ascx.cs" Inherits="OurUmbraco.Our.usercontrols.ProjectEditor" %>
 
 <asp:PlaceHolder runat="server" ID="notallowed" Visible="False">
-    <h2>Sorry, your account is too new to create projects! If you're human, make sure to <a href="https://umbraco.com/about-us/team">get in touch with us</a> to get this restriction lifted.</h2>
+    <h2>Sorry, your account is too new to create projects! If you're human, make sure to <a href="https://umbraco.com/contact-us/">get in touch with us</a> to get this restriction lifted.</h2>
 </asp:PlaceHolder>
 
 <asp:PlaceHolder ID="holder" runat="server">

--- a/OurUmbraco/Project/usercontrols/Deli/Profile/__MyProjects.ascx
+++ b/OurUmbraco/Project/usercontrols/Deli/Profile/__MyProjects.ascx
@@ -17,7 +17,7 @@
     }
 %>
 <asp:PlaceHolder runat="server" ID="notallowed" Visible="False">
-    <h2>Sorry, your account is too new to create projects! If you're human, make sure to <a href="https://umbraco.com/about-us/team">get in touch with us</a> to get this restriction lifted.</h2>
+    <h2>Sorry, your account is too new to create projects! If you're human, make sure to <a href=https://umbraco.com/contact-us/">get in touch with us</a> to get this restriction lifted.</h2>
 </asp:PlaceHolder>
 <asp:PlaceHolder runat="server" ID="holder">
     <div class="profile-settings">


### PR DESCRIPTION
The "get in touch with us" pointed to : https://umbraco.com/about-us/team/ which does not exist.

I thought it be better if it led the user to the contact us page: https://umbraco.com/contact-us/
(thats at least where I asked to get that restriction lifted 😀)

![image](https://user-images.githubusercontent.com/1050133/96881555-add84a00-147e-11eb-8bad-a0d5f499486d.png)

I updated all links to that particular page in the code. 