### PR TITLE
Adding the new team members to the stats

### DIFF
--- a/OurUmbraco.Site/config/TeamUmbraco.json
+++ b/OurUmbraco.Site/config/TeamUmbraco.json
@@ -9,11 +9,11 @@
 	"Members": ["abjerner", "emmaburstow", "kjac", "poornimanayar"]
 }, {
 	"TeamName": "UmbPack",
-	"Members": []
+	"Members": ["dawoe", "KevinJump", "lottepitcher", "Mantus667", "NikRimington", "Rockerby"]
 }, {
 	"TeamName": "Umbraco.Packages",
-	"Members": []
+	"Members": ["dawoe", "KevinJump", "lottepitcher", "Mantus667", "NikRimington", "Rockerby"]
 }, {
 	"TeamName": "Package.Templates",
-	"Members": []
+	"Members": ["dawoe", "KevinJump", "lottepitcher", "Mantus667", "NikRimington", "Rockerby"]
 }]

--- a/OurUmbraco.Site/config/TeamUmbraco.json
+++ b/OurUmbraco.Site/config/TeamUmbraco.json
@@ -1,16 +1,19 @@
 [{
 	"TeamName": "Umbraco-CMS",
-	"Members": [
-		"abjerner", "kjac", "emmaburstow", "poornimanayar", 
-	]
+	"Members": ["abjerner", "emmaburstow", "kjac", "poornimanayar"]
 }, {
 	"TeamName": "UmbracoDocs",
-	"Members": [
-		"busraparnell", "dampee", "jeavon", "marcemarc", "sophie-neale"
-	]
+	"Members": ["busraparnell", "dampee", "jeavon", "marcemarc", "sophie-neale"]
 }, {
 	"TeamName": "OurUmbraco",
-	"Members": [
-		"abjerner", "kjac", "emmaburstow", "poornimanayar"
-	]
+	"Members": ["abjerner", "emmaburstow", "kjac", "poornimanayar"]
+}, {
+	"TeamName": "UmbPack",
+	"Members": []
+}, {
+	"TeamName": "Umbraco.Packages",
+	"Members": []
+}, {
+	"TeamName": "Package.Templates",
+	"Members": []
 }]

--- a/OurUmbraco.Site/config/TeamUmbraco.json
+++ b/OurUmbraco.Site/config/TeamUmbraco.json
@@ -1,12 +1,12 @@
 [{
 	"TeamName": "Umbraco-CMS",
-	"Members": ["abjerner", "emmaburstow", "kjac", "poornimanayar"]
+	"Members": ["abjerner", "emmaburstow", "glombek", "kjac", "lssweatherhead", "mikecp", "nathanwoulfe", "owainwilliams", "poornimanayar"]
 }, {
 	"TeamName": "UmbracoDocs",
 	"Members": ["busraparnell", "dampee", "jeavon", "marcemarc", "sophie-neale"]
 }, {
 	"TeamName": "OurUmbraco",
-	"Members": ["abjerner", "emmaburstow", "kjac", "poornimanayar"]
+	"Members": ["abjerner", "emmaburstow", "glombek", "kjac", "lssweatherhead", "mikecp", "nathanwoulfe", "owainwilliams", "poornimanayar"]
 }, {
 	"TeamName": "UmbPack",
 	"Members": ["dawoe", "KevinJump", "lottepitcher", "Mantus667", "NikRimington", "Rockerby"]

--- a/OurUmbraco.Site/config/TeamUmbraco.json
+++ b/OurUmbraco.Site/config/TeamUmbraco.json
@@ -6,7 +6,7 @@
 }, {
 	"TeamName": "UmbracoDocs",
 	"Members": [
-		"dampee", "jeavon", "marcemarc"
+		"busraparnell", "dampee", "jeavon", "marcemarc", "sophie-neale"
 	]
 }, {
 	"TeamName": "OurUmbraco",


### PR DESCRIPTION
Does what it says on the tin... I have added the [new community team members](https://umbraco.com/blog/the-community-teams-applications-20202021/) to the teams JSON file.

The file is used to identify team member activity and track stats.