### PR TITLE
adding Package.Templates as an umbraco public repository

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Community/Home.cshtml
@@ -157,6 +157,7 @@ else
                                 <a href="https://github.com/umbraco/Umbraco.Courier.Contrib" target="_blank" rel="noreferrer noopener" title="Umbraco.Courier.Contrib">Umbraco.Courier.Contrib</a>,
                                 <a href="https://github.com/umbraco/Umbraco.Deploy.ValueConnectors" target="_blank" rel="noreferrer noopener" title="Umbraco.Deploy.ValueConnectors">Umbraco.Deploy.ValueConnectors</a>,
                                 <a href="https://github.com/umbraco/UmbPack" target="_blank" rel="noreferrer noopener" title="UmbPack">UmbPack</a>,
+                                <a href="https://github.com/umbraco/Package.Templates" target="_blank" rel="noreferrer noopener" title="Package.Templates">Package.Templates</a>,
                                 <a href="https://github.com/umbraco/rfcs" target="_blank" rel="noreferrer noopener" title="RFCs">RFCs</a>,
                                 <a href="https://github.com/umbraco/The-Starter-Kit" target="_blank" rel="noreferrer noopener" title="The-Starter-Kit">The-Starter-Kit</a> and
                                 <a href="https://github.com/umbraco/organizer-guide" target="_blank" rel="noreferrer noopener" title="organizer-guide">organizer-guide</a> repos

--- a/OurUmbraco.Site/config/GitHubPublicRepositories.json
+++ b/OurUmbraco.Site/config/GitHubPublicRepositories.json
@@ -70,5 +70,11 @@
     "Owner": "umbraco",
     "Slug": "UmbPack",
     "Name": "UmbPack"
+  },
+  {
+    "Alias": "Package.Templates",
+    "Owner": "umbraco",
+    "Slug": "Package.Templates",
+    "Name": "Package.Templates"
   }
 ]

--- a/OurUmbraco/Community/GitHub/GitHubService.cs
+++ b/OurUmbraco/Community/GitHub/GitHubService.cs
@@ -304,6 +304,7 @@ namespace OurUmbraco.Community.GitHub
                 "Umbraco.Deploy.Contrib",
                 "Umbraco.Deploy.ValueConnectors",
                 "UmbPack",
+                "Package.Templates",
                 "rfcs",	
                 "organizer-guide",
                 "The-Starter-Kit"


### PR DESCRIPTION
The [Package.Templates repository](https://github.com/umbraco/Package.Templates) now has contribution guidelines, so could it be listed to the list of repos that are considered for home page stats?  If so this PR adds this to the home page links, the json and the GitHub service (i.e. all the places that were updated in this commit: https://github.com/umbraco/OurUmbraco/commit/d9603fd85a274cd332b36daa9bbf2cb35d1e8ec7 when adding umbPack)

Don't know what the order of things should be, but I've added it after UmbPack:

![image](https://user-images.githubusercontent.com/4716542/97749687-6473a480-1ae7-11eb-9205-44102532ffb3.png)