### PR TITLE
renable contrib badge bot, with optional commenting

### DIFF
--- a/OurUmbraco.Client/package.json
+++ b/OurUmbraco.Client/package.json
@@ -6,9 +6,9 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
-    "gulp-clean-css": "4.0.0",
     "gulp": "4.0.0",
     "gulp-autoprefixer": "6.0.0",
+    "gulp-clean-css": "4.0.0",
     "gulp-concat": "2.6.1",
     "gulp-imagemin": "5.0.3",
     "gulp-jshint": "^2.1.0",
@@ -18,7 +18,7 @@
     "gulp-uglify": "3.0.1",
     "gulp-util": "3.0.8",
     "gulp-watch": "5.0.1",
-    "jshint": "^2.9.7",
+    "jshint": "^2.12.0",
     "jshint-stylish": "2.2.1",
     "node-sass": "4.14.1"
   },

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\UmbracoCms.7.15.3\build\UmbracoCms.props" Condition="Exists('..\packages\UmbracoCms.7.15.3\build\UmbracoCms.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\packages\UmbracoCms.7.15.3\build\UmbracoCms.props" Condition="Exists('..\packages\UmbracoCms.7.15.3\build\UmbracoCms.props')" />
   <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -4535,9 +4535,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.205\build\LibGit2Sharp.NativeBinaries.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('..\packages\UmbracoCms.7.15.3\build\UmbracoCms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UmbracoCms.7.15.3\build\UmbracoCms.props'))" />
     <Error Condition="!Exists('..\packages\UmbracoCms.7.15.3\build\UmbracoCms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UmbracoCms.7.15.3\build\UmbracoCms.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
   <Import Project="..\packages\UmbracoCms.7.15.3\build\UmbracoCms.targets" Condition="Exists('..\packages\UmbracoCms.7.15.3\build\UmbracoCms.targets')" />
   <Import Project="..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />

--- a/OurUmbraco/NotificationsCore/Notifications/MarkAsSolutionReminder.cs
+++ b/OurUmbraco/NotificationsCore/Notifications/MarkAsSolutionReminder.cs
@@ -24,7 +24,10 @@ namespace OurUmbraco.NotificationsCore.Notifications
                 {
                     var memberShipHelper = new MembershipHelper(UmbracoContext.Current);
                     var member = memberShipHelper.GetById(memberId);
-                    
+
+                    if (member == null)
+                        return;
+
                     using (var smtpClient = new SmtpClient())
                     {
                         var fromMailAddress = new MailAddress(notificationMail.FromMail, notificationMail.FromName);


### PR DESCRIPTION
As part of the community teams catchup last week, we identified a few areas for improving the core contributions experience - one of which being automatically adding the contrib badge to Our profiles. Despite several in attendance having also been at the 2019 retreat, we forgot that this had been tackled already.

The automation code was disabled by a feature flag, most likely because at the time it was added, few Our profiles would have had the GitHub account linked. That's no longer the case, so we figured it's safe to turn it back on. To make it a bit safer, I've added an additional app setting to disable comments - this means the bot can be enabled silently, if we want to turn it on and monitor it for a while, without firing off comments to PRs.

For that to work, the web config needs two new app settings added (file is excluded from source control). Keys are:
````xml
<add key="EnableContribBadgeBot" value="#{EnableContribBadgeBot}#" />
<add key="EnableContribBadgeBotComments" value="#{EnableContribBadgeBotComments}#" />
````

Everything else is largely unchanged - I tweaked the comment text a little and updated a couple of variable names, nothing major. Added a null-check in MarkAsSolutionReminder because it kept throwing errors on local.