### PR TITLE
Fix package listings layout and downloads counts

### DIFF
--- a/OurUmbraco.Client/src/scss/sections/_packages.scss
+++ b/OurUmbraco.Client/src/scss/sections/_packages.scss
@@ -28,7 +28,7 @@ section.packages {
     }
 
     .package-box {
-        display: block;
+        display: flex;
         flex-flow: column;
         align-items: center;
         border: 1px solid darken(#f6f6f6, 5%);
@@ -77,6 +77,7 @@ section.packages {
         }
 
         .package-image {
+            width:100%;
             text-align: center;
             padding: 10px;
 

--- a/OurUmbraco.Client/src/scss/sections/_packages.scss
+++ b/OurUmbraco.Client/src/scss/sections/_packages.scss
@@ -30,7 +30,7 @@ section.packages {
     .package-box {
         display: flex;
         flex-flow: column;
-        align-items: center;
+        align-items: stretch;
         border: 1px solid darken(#f6f6f6, 5%);
         transition: box-shadow .2s ease, border-color .2s ease;
         margin: 0px 7px 15px;
@@ -44,6 +44,7 @@ section.packages {
         .package-info {
             text-align: center;
             margin: 0 10px 20px;
+            flex-grow: 2;
 
             .small {
                 font-size: 14px;
@@ -77,7 +78,6 @@ section.packages {
         }
 
         .package-image {
-            width:100%;
             text-align: center;
             padding: 10px;
 

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -1,5 +1,7 @@
 ﻿@using OurUmbraco.Repository.Controllers
 @using OurUmbraco.Repository.Models
+@using OurUmbraco.Project
+
 @inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 @{
     //This is the main Our project search
@@ -29,7 +31,7 @@
     }
 
     var url = string.Format("orderBy={0}&q={1}&version={2}&category={3}", orderMode, term, version, category);
-    
+
     var searchOrder = GetSortOrder(orderMode);
 
     var packageService = new OurUmbraco.Repository.Services
@@ -84,7 +86,7 @@ else
         <div class="package-info">
             <h3>@projectContent.Name</h3>
             <span class="text-fadeout"></span>
-            <p class="small">@projectContent.Summary</p>
+            <p class="small">@Html.Raw(projectContent.Summary.CleanHtmlAttributes())</p>
         </div>
 
         <div class="other">

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -95,8 +95,8 @@ else
                 <span class="karma">
                     @projectContent.Likes <span><i class="icon-Hearts color-red"></i></span>
                 </span>
-                <span class="downloads">
-                    @projectContent.Downloads <span><i class="icon-Download-alt"></i></span>
+                <span class="downloads" title="@projectContent.Downloads total downloads">
+                    @FormatDownloadNumber(projectContent.Downloads) <span><i class="icon-Download-alt"></i></span>
                 </span>
             </div>
         </div>
@@ -126,5 +126,25 @@ else
         }
 
         return PackageSortOrder.Popular;
+    }
+
+    public string FormatDownloadNumber(int downloads)
+    {
+        if (downloads > 999999999)
+        {
+            return downloads.ToString("0,,,.###B", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else if (downloads > 999999)
+        {
+            return downloads.ToString("0,,.##M", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else if (downloads > 999)
+        {
+            return downloads.ToString("0,.#K", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            return downloads.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
     }
 }

--- a/OurUmbraco.Site/Views/Partials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ProjectDetails.cshtml
@@ -435,17 +435,17 @@
                                     <span>License</span> <a href="@licenseUrl" target="_blank" rel="noreferrer noopener">@project.GetPropertyValue("licenseName")</a>
                                 </li>
 
-                                <li>
-                                    <span>Downloads on Our:</span> @ourDownloads
+                                <li title="@ourDownloads on our.umbraco.com">
+                                    <span>Downloads on Our:</span> @FormatDownloadNumber(ourDownloads) 
                                 </li>
 
                                 @if (nugetDownloads > 0)
                                 {
-                                    <li>
-                                        <span>Downloads on NuGet:</span> @nugetDownloads
+                                    <li title="@nugetDownloads downloads on nuget">
+                                        <span>Downloads on NuGet:</span> @FormatDownloadNumber(nugetDownloads)
                                     </li>
-                                    <li>
-                                        <span>Total downloads : </span> @(nugetDownloads + ourDownloads)
+                                    <li title="@(nugetDownloads + ourDownloads) total downloads">
+                                        <span>Total downloads : </span> @FormatDownloadNumber(nugetDownloads + ourDownloads)
                                     </li>
                                 }
                             </ul>
@@ -529,5 +529,27 @@ else
     else
     {
         <text>@count @pluralValue</text>
+    }
+}
+
+@functions {
+    public string FormatDownloadNumber(int downloads)
+    {
+        if (downloads > 999999999)
+        {
+            return downloads.ToString("0,,,.###B", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else if (downloads > 999999)
+        {
+            return downloads.ToString("0,,.##M", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else if (downloads > 999)
+        {
+            return downloads.ToString("0,.#K", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            return downloads.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
     }
 }


### PR DESCRIPTION
Fixes potential layout issue when packages reach 1 million downloads
see : https://github.com/umbraco/Umbraco.Packages/issues/107

this update changes the number format for downloads to display in 1000's (e.g 134.5K) or millions (1.1M) on both the package listing and package info pages. 

![image](https://user-images.githubusercontent.com/431231/102010594-ec7bd980-3d36-11eb-94f9-caf207122898.png)

should also resolve the alignment issue on the package listing page, where the bottom of the boxes doesn't always line up:

For layout, 
![image](https://user-images.githubusercontent.com/431231/102010950-2cdc5700-3d39-11eb-9255-52518b2b0309.png)

becomes (the version and download info is now aligned). 

![image](https://user-images.githubusercontent.com/431231/102010946-2352ef00-3d39-11eb-8792-f0ab737c890d.png)

