### PR TITLE
Rewrites for the new Fundamentals section of docs

### DIFF
--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -595,7 +595,7 @@
             	    <match url="documentation/Getting-Started/Design/*" />
                     <action type="Redirect" url="/Documentation/Fundamentals/Design/" redirectType="Permanent" appendQueryString="true" />
                 </rule>
-		<rule name="Design" patternSyntax="Wildcard">
+		<rule name="Code" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Code/*" />
                     <action type="Redirect" url="/Documentation/Fundamentals/Code/" redirectType="Permanent" appendQueryString="true" />
                 </rule>

--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -579,7 +579,6 @@
                     <match url="rss/wiki*" />
                     <action type="Redirect" url="/Documentation/" redirectType="Permanent" appendQueryString="true" />
                 </rule>
-		<!-- START - Renaming Getting Started to Fundamentals -->
 		<rule name="Setup" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Setup/*" />
                     <action type="Redirect" url="/Documentation/Fundamentals/Setup/" redirectType="Permanent" appendQueryString="true" />
@@ -600,7 +599,6 @@
             	    <match url="documentation/Getting-Started/Code/*" />
                     <action type="Redirect" url="/Documentation/Fundamentals/Code/" redirectType="Permanent" appendQueryString="true" />
                 </rule>
-		<!-- END -->
                 <rule name="MemberProjectsToPackages" patternSyntax="Wildcard">
                     <match url="member/profile/projects/*" />
                     <action type="Redirect" redirectType="Permanent" appendQueryString="true" url="/member/profile/packages/{R:1}" />

--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -579,6 +579,28 @@
                     <match url="rss/wiki*" />
                     <action type="Redirect" url="/Documentation/" redirectType="Permanent" appendQueryString="true" />
                 </rule>
+		<!-- START - Renaming Getting Started to Fundamentals -->
+		<rule name="Setup" patternSyntax="Wildcard">
+            	    <match url="documentation/Getting-Started/Setup/*" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Setup/" redirectType="Permanent" appendQueryString="true" />
+                </rule>
+		<rule name="Backoffice" patternSyntax="Wildcard">
+            	    <match url="documentation/Getting-Started/Backoffice/*" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Backoffice/" redirectType="Permanent" appendQueryString="true" />
+                </rule>
+		<rule name="Data" patternSyntax="Wildcard">
+            	    <match url="documentation/Getting-Started/Data/*" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Data/" redirectType="Permanent" appendQueryString="true" />
+                </rule>
+		<rule name="Design" patternSyntax="Wildcard">
+            	    <match url="documentation/Getting-Started/Design/*" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Design/" redirectType="Permanent" appendQueryString="true" />
+                </rule>
+		<rule name="Design" patternSyntax="Wildcard">
+            	    <match url="documentation/Getting-Started/Code/*" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Code/" redirectType="Permanent" appendQueryString="true" />
+                </rule>
+		<!-- END -->
                 <rule name="MemberProjectsToPackages" patternSyntax="Wildcard">
                     <match url="member/profile/projects/*" />
                     <action type="Redirect" redirectType="Permanent" appendQueryString="true" url="/member/profile/packages/{R:1}" />


### PR DESCRIPTION
**This PR is dependant on a Docs PR: https://github.com/umbraco/UmbracoDocs/pull/3092.
Do not merge this before the Docs PR has been merged.**

We're in the process of implementing a new Getting Started section in the Documentation.

The current "Getting Started" section will be renamed Fundamentals.
The rewrites added in this PR should make sure that everything from the old Getting Started section is redirected over to the Fundamentals section.
There is a rewrite rule for each if the sub-sections in the Getting Started section, and they are redirected to their new path in the Fundamentals section.