### PR TITLE
Always show versioning box

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
@@ -92,16 +92,16 @@
     var currentUmbracoVersion = int.Parse(docVersionService.GetCurrentMajorVersion());
 }
 
-@if (hasAltVersions)
-{
-    <aside>
-        <div class="info-box docs-version-panel">
-            <dl>
-                @*<dt>Applies to</dt>
-                    <dd>v8.0.0</dd>*@
+<aside>
+    <div class="info-box docs-version-panel">
+        <dl>
+            @*<dt>Applies to</dt>
+                <dd>v8.0.0</dd>*@
 
-                <dt>@*Alternate*@ Versions</dt>
-                @foreach (var version in altVersions)
+            <dt>@*Alternate*@ Versions</dt>
+            @if (hasAltVersions)
+            {
+                foreach (var version in altVersions)
                 {
                     <dd class="@Umbraco.If(version.IsCurrentVersion, "current-version") @Umbraco.If(version.IsCurrentPage, "selected-version")">
                         @if (version.IsCurrentPage)
@@ -118,11 +118,16 @@
                         }
                     </dd>
                 }
-
-            </dl>
-        </div>
-    </aside>
-}
+            }
+            else if (currentVersion != null)
+            {
+                <dd class="current-version selected-version">
+                    @(currentVersion.Version)
+                </dd>
+            }
+        </dl>
+    </div>
+</aside>
 
 @if (string.IsNullOrWhiteSpace(Request.QueryString["debug"]) == false)
 {


### PR DESCRIPTION
We want to have the versions box show, whenever the "versionFrom" meta data is used on an article.