### PR TITLE
Update rewrite rules for new Fundementals section.

### DIFF
--- a/OurUmbraco.Site/web.vsts.config
+++ b/OurUmbraco.Site/web.vsts.config
@@ -581,23 +581,23 @@
                 </rule>
 		<rule name="Setup" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Setup/*" />
-                    <action type="Redirect" url="/Documentation/Fundamentals/Setup/" redirectType="Permanent" appendQueryString="true" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Setup/{R:1}" redirectType="Permanent" appendQueryString="true" />
                 </rule>
 		<rule name="Backoffice" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Backoffice/*" />
-                    <action type="Redirect" url="/Documentation/Fundamentals/Backoffice/" redirectType="Permanent" appendQueryString="true" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Backoffice/{R:1}" redirectType="Permanent" appendQueryString="true" />
                 </rule>
 		<rule name="Data" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Data/*" />
-                    <action type="Redirect" url="/Documentation/Fundamentals/Data/" redirectType="Permanent" appendQueryString="true" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Data/{R:1}" redirectType="Permanent" appendQueryString="true" />
                 </rule>
 		<rule name="Design" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Design/*" />
-                    <action type="Redirect" url="/Documentation/Fundamentals/Design/" redirectType="Permanent" appendQueryString="true" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Design/{R:1}" redirectType="Permanent" appendQueryString="true" />
                 </rule>
 		<rule name="Code" patternSyntax="Wildcard">
             	    <match url="documentation/Getting-Started/Code/*" />
-                    <action type="Redirect" url="/Documentation/Fundamentals/Code/" redirectType="Permanent" appendQueryString="true" />
+                    <action type="Redirect" url="/Documentation/Fundamentals/Code/{R:1}" redirectType="Permanent" appendQueryString="true" />
                 </rule>
                 <rule name="MemberProjectsToPackages" patternSyntax="Wildcard">
                     <match url="member/profile/projects/*" />


### PR DESCRIPTION
I've tested this on my local instance of Our, and links to the "old" Getting Started section, should now redirect correctly to the same article within the new Fundamentals sections.

E.g.
`/documentation/getting-started/backoffice/property-editors/built-in-property-editors/Nested-Content/`
now redirects to
`/Documentation/Fundamentals/Backoffice/property-editors/built-in-property-editors/Nested-Content/`
instead of "just" the `/Documentation/Fundamentals/Backoffice/` index page.