### PR TITLE
Added flag for packages certified to work on Umbraco Cloud to the packages API response.

### DIFF
--- a/OurUmbraco/Repository/Models/Package.cs
+++ b/OurUmbraco/Repository/Models/Package.cs
@@ -51,5 +51,10 @@ namespace OurUmbraco.Repository.Models
         ///  shorter summary shown on our.umbraco.com
         /// </summary>
         public string Summary { get; set; }
+
+        /// <summary>
+        /// A flag indicating whether the package has been certified to work on Umbraco Cloud.
+        /// </summary>
+        public bool CertifiedToWorkOnUmbracoCloud { get; set; }
     }
 }

--- a/OurUmbraco/Repository/Services/PackageRepositoryService.cs
+++ b/OurUmbraco/Repository/Services/PackageRepositoryService.cs
@@ -239,7 +239,8 @@ namespace OurUmbraco.Repository.Services
                 Score = score,
                 VersionRange = version,
                 Image = BASE_URL + content.GetPropertyValue<string>("defaultScreenshotPath", "/css/img/package2.png"),
-                Summary = GetPackageSummary(content, 50)
+                Summary = GetPackageSummary(content, 50),
+                CertifiedToWorkOnUmbracoCloud = content.GetPropertyValue<bool>("worksOnUaaS"),
             };
         }
 


### PR DESCRIPTION
This change is to support a change to the Packages section in the Umbraco office, allowing the display of a badge or similar for those packages that are certified to work with Umbraco Cloud.