### PR TITLE
Fixed forum comments from shifting down when hovered over

### DIFF
--- a/OurUmbraco.Client/src/scss/elements/_forum-thread.scss
+++ b/OurUmbraco.Client/src/scss/elements/_forum-thread.scss
@@ -342,6 +342,7 @@
 
 				span {
 					display: none;
+					line-height: 1;
 				}
 
 				i {


### PR DESCRIPTION
The labels on comment action buttons had a `line-height` of 1.3, whilst their icons had a `line-height` of 1, this was causing everything below them to shift slightly down when they became visible.

**Current behaviour:**
![OurUmbraco - comment action button line height - old](https://user-images.githubusercontent.com/17008780/135891654-b9af9e2c-81fa-4a42-a468-e49813ec8706.gif)

I fixed this by changing the `line-height` of the labels to 1, so that they match the `line-height` of their icons, and no longer shifts the content down when they become visible.

**Fixed behaviour:**
![OurUmbraco - comment action button line height - new](https://user-images.githubusercontent.com/17008780/135891742-eb8ce7bd-f8d1-443a-aefb-127694ddc2c9.gif)

I've tested on Edge, Chrome and Firefox.
