### PR TITLE
Adds back-office management, display and API updates to support promoted packages in the back-office and on our.umbraco.com.

### DIFF
--- a/OurUmbraco.Site/App_Code/RenderProjectHelpers.cshtml
+++ b/OurUmbraco.Site/App_Code/RenderProjectHelpers.cshtml
@@ -1,0 +1,60 @@
+﻿@using OurUmbraco.Our
+@using OurUmbraco.Repository.Models
+@using OurUmbraco.Project
+
+@helper RenderProjectBox(Package projectContent)
+{
+    <a class="package-box" href="@projectContent.Url">
+        <div class="package-image">
+            @RenderProjectImage(Utils.GetScreenshotPath(projectContent.Image))
+        </div>
+        <div class="package-info">
+            <h3>@projectContent.Name</h3>
+            <span class="text-fadeout"></span>
+            <p class="small">@(new HtmlString(projectContent.Summary.CleanHtmlAttributes()))</p>
+        </div>
+
+        <div class="other">
+            <div class="package-badge">
+                <span class="package-number">@projectContent.VersionRange</span>
+            </div>
+            <div class="stats">
+                <span class="karma">
+                    @projectContent.Likes <span><i class="icon-Hearts color-red"></i></span>
+                </span>
+                <span class="downloads" title="@projectContent.Downloads total downloads">
+                    @FormatDownloadNumber(projectContent.Downloads) <span><i class="icon-Download-alt"></i></span>
+                </span>
+            </div>
+        </div>
+    </a>
+}
+
+@helper RenderProjectImage(string defaultScreenshot)
+{
+    <img src="@defaultScreenshot?width=64&height=64&bgcolor=fff&format=png"
+         srcset="@defaultScreenshot?width=128&height=128&bgcolor=fff&format=png 2x,
+             @defaultScreenshot?width=192&height=192&bgcolor=fff&format=png 3x" />
+}
+
+@functions{
+    public static string FormatDownloadNumber(int downloads)
+    {
+        if (downloads > 999999999)
+        {
+            return downloads.ToString("0,,,.###B", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else if (downloads > 999999)
+        {
+            return downloads.ToString("0,,.##M", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else if (downloads > 999)
+        {
+            return downloads.ToString("0,.#K", System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            return downloads.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/OurUmbraco.Site/OurUmbraco.Site.csproj
+++ b/OurUmbraco.Site/OurUmbraco.Site.csproj
@@ -4481,6 +4481,8 @@
     <Content Include="Views\Partials\Projects\SortOrderDropdown.cshtml" />
     <Content Include="Views\Partials\Projects\projectactions.cshtml" />
     <Content Include="Views\Partials\Projects\searchtemplate.cshtml" />
+    <Content Include="Views\Partials\Projects\ListPromotedProjects.cshtml" />
+    <Content Include="App_Code\RenderProjectHelpers.cshtml" />
     <None Include="web.Debug.config">
       <DependentUpon>web.config</DependentUpon>
     </None>

--- a/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListProjects.cshtml
@@ -1,7 +1,4 @@
-﻿@using OurUmbraco.Our
-@using OurUmbraco.Repository.Controllers
-@using OurUmbraco.Repository.Models
-@using OurUmbraco.Project
+﻿@using OurUmbraco.Repository.Controllers
 
 @inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
 @{
@@ -44,7 +41,7 @@
 <div class="packages-listing">
     @foreach (var childContent in results.Packages)
     {
-        @RenderProjectBox(childContent)
+        @RenderProjectHelpers.RenderProjectBox(childContent)
     }
 </div>
 
@@ -77,44 +74,9 @@ else
     *@
 }
 
-
-@helper RenderProjectBox(Package projectContent)
+@functions
 {
-    <a class="package-box" href="@projectContent.Url">
-        <div class="package-image">
-            @RenderProjectImage(Utils.GetScreenshotPath(projectContent.Image))
-        </div>
-        <div class="package-info">
-            <h3>@projectContent.Name</h3>
-            <span class="text-fadeout"></span>
-            <p class="small">@Html.Raw(projectContent.Summary.CleanHtmlAttributes())</p>
-        </div>
-
-        <div class="other">
-            <div class="package-badge">
-                <span class="package-number">@projectContent.VersionRange</span>
-            </div>
-            <div class="stats">
-                <span class="karma">
-                    @projectContent.Likes <span><i class="icon-Hearts color-red"></i></span>
-                </span>
-                <span class="downloads" title="@projectContent.Downloads total downloads">
-                    @FormatDownloadNumber(projectContent.Downloads) <span><i class="icon-Download-alt"></i></span>
-                </span>
-            </div>
-        </div>
-    </a>
-}
-
-@helper RenderProjectImage(string defaultScreenshot)
-{
-    <img src="@defaultScreenshot?width=64&height=64&bgcolor=fff&format=png"
-         srcset="@defaultScreenshot?width=128&height=128&bgcolor=fff&format=png 2x,
-             @defaultScreenshot?width=192&height=192&bgcolor=fff&format=png 3x" />
-}
-
-@functions{
-    public PackageSortOrder GetSortOrder(string orderMode)
+    public static PackageSortOrder GetSortOrder(string orderMode)
     {
         switch (orderMode.ToLower())
         {
@@ -129,25 +91,5 @@ else
         }
 
         return PackageSortOrder.Popular;
-    }
-
-    public string FormatDownloadNumber(int downloads)
-    {
-        if (downloads > 999999999)
-        {
-            return downloads.ToString("0,,,.###B", System.Globalization.CultureInfo.InvariantCulture);
-        }
-        else if (downloads > 999999)
-        {
-            return downloads.ToString("0,,.##M", System.Globalization.CultureInfo.InvariantCulture);
-        }
-        else if (downloads > 999)
-        {
-            return downloads.ToString("0,.#K", System.Globalization.CultureInfo.InvariantCulture);
-        }
-        else
-        {
-            return downloads.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        }
     }
 }

--- a/OurUmbraco.Site/Views/Partials/Projects/ListPromotedProjects.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Projects/ListPromotedProjects.cshtml
@@ -1,0 +1,35 @@
+﻿@using OurUmbraco.Repository.Controllers
+
+@inherits OurUmbraco.Our.Models.OurUmbracoTemplatePage
+@{
+    var pageSize = 20;
+
+    var packageService = new OurUmbraco.Repository.Services
+        .PackageRepositoryService(Umbraco, Members, ApplicationContext.Current.DatabaseContext);
+
+    var results = packageService.GetPackages(0, pageSize, order: PackageSortOrder.Popular, onlyPromoted: true);
+    if (results.Total == 0)
+    {
+        // Don't display the section if there are no promoted packages.
+        return;
+    }
+}
+
+<div class="row">
+    <div class="col-xs-12">
+        <div class="packages-filter-bar">
+            <h3 style="font-size: 1.4em; font-weight: 700;">Promoted</h3>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12">
+        <div class="packages-listing">
+            @foreach (var childContent in results.Packages)
+            {
+                @RenderProjectHelpers.RenderProjectBox(childContent)
+            }
+        </div>
+    </div>
+</div>
+

--- a/OurUmbraco.Site/Views/Projects.cshtml
+++ b/OurUmbraco.Site/Views/Projects.cshtml
@@ -88,7 +88,10 @@
                     </div>
                 </div>
 
+                @*
+                Hidden as for now will only display promoted packages in the back-office, not on our.umbraco.com.
                 @Html.Partial("~/Views/Partials/Projects/ListPromotedProjects.cshtml", Model.Content)
+                *@
 
                 <div class="row">
                     <div class="col-xs-12">

--- a/OurUmbraco.Site/Views/Projects.cshtml
+++ b/OurUmbraco.Site/Views/Projects.cshtml
@@ -60,7 +60,6 @@
                         <nav role="navigation">
                             <a href="?page=1&orderBy=@orderMode">See more &raquo;</a>
                         </nav>
-
                     }
                     else
                     {
@@ -88,6 +87,8 @@
                         @Html.Partial("~/Views/Partials/Projects/ListProjects.cshtml", Model.Content, new ViewDataDictionary() { { "orderBy", "popularity" }, { "isHome", isHome } })
                     </div>
                 </div>
+
+                @Html.Partial("~/Views/Partials/Projects/ListPromotedProjects.cshtml", Model.Content)
 
                 <div class="row">
                     <div class="col-xs-12">

--- a/OurUmbraco.Site/config/ExamineIndex.config
+++ b/OurUmbraco.Site/config/ExamineIndex.config
@@ -108,6 +108,7 @@ More information and documentation can be found on CodePlex: http://umbracoexami
             <add Name="minimumVersionStrict" />
             <add Name="isRetired" />
             <add Name="isNuGetFormat" />
+            <add Name="isPromoted" />
         </IndexUserFields>
     </IndexSet>
 

--- a/OurUmbraco/Our/Examine/ProjectNodeIndexDataService.cs
+++ b/OurUmbraco/Our/Examine/ProjectNodeIndexDataService.cs
@@ -41,6 +41,7 @@ namespace OurUmbraco.Our.Examine
         {
             var isLive = project.GetPropertyValue<bool>("projectLive");
             var isApproved = project.GetPropertyValue<bool>("approved");
+            var isPromoted = project.GetPropertyValue<bool>("isPromoted");
 
             var strictPackageFiles = PackageRepositoryService.GetAllStrictSupportedPackageVersions(files);
             
@@ -113,6 +114,7 @@ namespace OurUmbraco.Our.Examine
 
             simpleDataSet.RowData.Add("projectLive", isLive ? "1" : "0");
             simpleDataSet.RowData.Add("approved", isApproved ? "1" : "0");
+            simpleDataSet.RowData.Add("isPromoted", isPromoted ? "1" : "0");
 
             //now we need to add the versions and compat versions
             // first, this is the versions that the project has files tagged against

--- a/OurUmbraco/Our/MigrationsHandler.cs
+++ b/OurUmbraco/Our/MigrationsHandler.cs
@@ -22,6 +22,7 @@ namespace OurUmbraco.Our
             GetReleasesJson();
             AddNewPackageFormatToggleToPackages();
             AddBannerPurposeToggleToPackages();
+            AddIsPromotedToggleToPackages();
         }
 
         private void EnsureMigrationsMarkerPathExists()
@@ -105,6 +106,41 @@ namespace OurUmbraco.Our
                         Mandatory = true
                     };
                     projectContentType.AddPropertyType(checkboxPropertyType, "Banner");
+                    contentTypeService.Save(projectContentType);
+                }
+
+                string[] lines = { "" };
+                File.WriteAllLines(path, lines);
+
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<MigrationsHandler>(string.Format("Migration: '{0}' failed", migrationName), ex);
+            }
+        }
+
+        private void AddIsPromotedToggleToPackages()
+        {
+            var migrationName = MethodBase.GetCurrentMethod().Name;
+
+            try
+            {
+                var path = HostingEnvironment.MapPath(MigrationMarkersPath + migrationName + ".txt");
+                if (File.Exists(path)) return;
+
+                var contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+                var projectContentType = contentTypeService.GetContentType("Project");
+                var propertyTypeAlias = "isPromoted";
+
+                if (projectContentType != null && projectContentType.PropertyTypeExists(propertyTypeAlias) == false)
+                {
+                    var checkbox = new DataTypeDefinition("Umbraco.TrueFalse");
+                    var checkboxPropertyType = new PropertyType(checkbox, propertyTypeAlias)
+                    {
+                        Name = "Is Promoted?",
+                        Description = "The package is selected for promotion (HQ, technical partner or selected community package)."
+                    };
+                    projectContentType.AddPropertyType(checkboxPropertyType, "Project");
                     contentTypeService.Save(projectContentType);
                 }
 

--- a/OurUmbraco/Our/Utils.cs
+++ b/OurUmbraco/Our/Utils.cs
@@ -252,7 +252,7 @@ namespace OurUmbraco.Our
                 LogHelper.Error<Utils>("Could not get Screenshot", ex);
             }
 
-            return "https://lorempixel.com/600/600/?" + rnd.Next();
+            return "https://picsum.photos/600/600/?" + rnd.Next();
         }
     }
 

--- a/OurUmbraco/Repository/Controllers/PackageRepositoryController.cs
+++ b/OurUmbraco/Repository/Controllers/PackageRepositoryController.cs
@@ -82,13 +82,14 @@ namespace OurUmbraco.Repository.Controllers
             string category = null,
             string query = null,
             string version = null,
-            PackageSortOrder order = PackageSortOrder.Latest)
+            PackageSortOrder order = PackageSortOrder.Latest,
+            bool onlyPromoted = false)
         {
             //return the results, but cache for 1 minute
-            var key = string.Format("PackageRepositoryController.GetCategories.{0}.{1}.{2}.{3}.{4}.{5}", pageIndex, pageSize, category ?? string.Empty, query ?? string.Empty, version ?? string.Empty, order);
+            var key = string.Format("PackageRepositoryController.GetCategories.{0}.{1}.{2}.{3}.{4}.{5}.{6}", pageIndex, pageSize, category ?? string.Empty, query ?? string.Empty, version ?? string.Empty, order, onlyPromoted);
             return ApplicationContext.ApplicationCache.RuntimeCache.GetCacheItem<PagedPackages>
                 (key,
-                    () => Service.GetPackages(pageIndex, pageSize, category, query, version, order),
+                    () => Service.GetPackages(pageIndex, pageSize, category, query, version, order, onlyPromoted: onlyPromoted),
                     TimeSpan.FromMinutes(1)); //cache for 1 min    
         }
 

--- a/OurUmbraco/Repository/Models/Package.cs
+++ b/OurUmbraco/Repository/Models/Package.cs
@@ -66,5 +66,10 @@ namespace OurUmbraco.Repository.Models
         /// Package is in the new NuGet-only format for v9+ sites
         /// </summary>
         public bool IsNuGetFormat { get; set; }
+
+        /// <summary>
+        /// The package is selected for promotion (HQ, technical partner or selected community package).
+        /// </summary>
+        public bool IsPromoted { get; set; }
     }
 }

--- a/OurUmbraco/Repository/Services/PackageRepositoryService.cs
+++ b/OurUmbraco/Repository/Services/PackageRepositoryService.cs
@@ -65,6 +65,7 @@ namespace OurUmbraco.Repository.Services
         /// <param name="version"></param>
         /// <param name="order"></param>
         /// <param name="includeHidden">Some packages are hidden (i.e. projectLive), set to true to ignore this switch (i.e. for starter kits)</param>
+        /// <param name="onlyPromoted">When flag set only promoted packages are returned.</param>
         /// <returns></returns>
         /// <remarks>
         /// This caches each query for 2 minutes (non-sliding)
@@ -76,7 +77,8 @@ namespace OurUmbraco.Repository.Services
             string query = null,
             string version = null,
             PackageSortOrder order = PackageSortOrder.Default,
-            bool? includeHidden = false)
+            bool? includeHidden = false,
+            bool? onlyPromoted = false)
         {
             var filters = new List<SearchFilters>();
             var searchFilters = new SearchFilters(BooleanOperation.And);
@@ -86,6 +88,11 @@ namespace OurUmbraco.Repository.Services
                 //MUST be live
                 searchFilters.Filters.Add(new SearchFilter("projectLive", "1"));
                 searchFilters.Filters.Add(new SearchFilter("isRetired", "0"));
+            }
+
+            if (onlyPromoted.HasValue && onlyPromoted.Value)
+            {
+                searchFilters.Filters.Add(new SearchFilter("isPromoted", "1"));
             }
 
             if (version.IsNullOrWhiteSpace() == false)
@@ -247,7 +254,8 @@ namespace OurUmbraco.Repository.Services
                 Summary = GetPackageSummary(content, 50),
                 CertifiedToWorkOnUmbracoCloud = content.GetPropertyValue<bool>("worksOnUaaS"),
                 NuGetPackageId = nuGetPackageId,
-                IsNuGetFormat =  content.GetPropertyValue<bool>("isNuGetFormat")
+                IsNuGetFormat =  content.GetPropertyValue<bool>("isNuGetFormat"),
+                IsPromoted = content.GetPropertyValue<bool>("isPromoted")
             };
         }
 


### PR DESCRIPTION
This PR adds the option for flagging certain packages as "promoted" (planned for HQ, as a technical partner benefit and to support selected community packages).  By selecting a package as promoted it'll appear in a new section under "Popular" and above "Latest", and also expose the information via the API so we can do a similar thing in the back-office.

Requires a new property on the "Project" document type:

```
Tab: Project
Alias: isPromoted
Name: Is Promoted?
Description: The package is selected for promotion (HQ, technical partner or selected community package).
```

I've reworked the templates slightly to allow for hiding of the whole "Promoted" section if there are none to promote, which required a new partial, and then to share some common helpers and functions between the new and existing template for listing packages.

