### PR TITLE
Enable NoFollow links on documentation

### DIFF
--- a/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
+++ b/OurUmbraco/Documentation/Busineslogic/MarkdownLogic.cs
@@ -63,6 +63,7 @@ namespace OurUmbraco.Documentation.Busineslogic
                     .UseTaskLists()
                     .UseDiagrams()
                     .UseAutoLinks()
+                    .UseNoFollowLinks() // needs to be replaced with .UseReferralLinks("nofollow") in a newer version of MarkDig
                     .UseSyntaxHighlighter(out SyntaxHighlighterOptions highligther)
                     .Build();
 


### PR DESCRIPTION
The documentation curators where thinking to enable the nofollow on the documentation to discourage people putting external links.