### PR TITLE
Remove 9+10 from search and change major docs version to 8

### DIFF
--- a/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
+++ b/OurUmbraco.Site/Views/DocumentationSubpage.cshtml
@@ -95,8 +95,6 @@
                                 <label for="search">Search for documentation</label>
                             </div>
                             <select class="version-search-select">
-                                <option value="10" selected="@(currentVersion == "10"? "selected" : null)">v10</option>
-                                <option value="9" selected="@(currentVersion == "9"? "selected" : null)">v9</option>
                                 <option value="8" selected="@(currentVersion == "8"? "selected" : null)">v8</option>
                                 <option value="7" selected="@(currentVersion == "7"? "selected" : null)">v7</option>
                                 <option value="6" selected="@(currentVersion == "6"? "selected" : null)">v6</option>

--- a/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Documentation/DisplayMarkdown.cshtml
@@ -117,7 +117,7 @@
                         }
                         @if (version.IsCurrentVersion)
                         {
-                            @:(current)
+                            @:
                         }
                     </dd>
                 }

--- a/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
+++ b/OurUmbraco.Site/Views/Partials/SearchResults.cshtml
@@ -32,8 +32,6 @@
                     <input type="hidden" name="cat" value="@Request.QueryString["cat"]" />
                     <label for="search">Search</label>
                     <select class="version-search-select" name="v" style="height: 60px; padding: 0; padding-left: 10px;">
-                        <option value="10" selected="@(Request.QueryString["v"] == "10"? "selected" : null)">v10</option>
-                        <option value="9" selected="@(Request.QueryString["v"] == "9"? "selected" : null)">v9</option>
                         <option value="8" selected="@(Request.QueryString["v"] == "8"? "selected" : null)">v8</option>
                         <option value="7" selected="@(Request.QueryString["v"] == "7"? "selected" : null)">v7</option>
                         <option value="6" selected="@(Request.QueryString["v"] == "6"? "selected" : null)">v6</option>

--- a/OurUmbraco/Our/Examine/OurSearcher.cs
+++ b/OurUmbraco/Our/Examine/OurSearcher.cs
@@ -66,7 +66,7 @@ namespace OurUmbraco.Our.Examine
             // * docs version (MajorDocsVersion) supplied, give current version and NEGATE OTHERS
             // * no docs version (MajorDocsVersion) is not suplied, use it and NEGATE others
             // * all versions are requests, this is currently not implemented
-            var currentMajorVersions = new string[] { "6", "7", "8", "9", "10" };
+            var currentMajorVersions = new string[] { "6", "7", "8" };
 
             // add mandatory majorVersion is parameter is supplied
             string versionToFilterBy = MajorDocsVersion == null


### PR DESCRIPTION
Don't merge this just yet!

This PR should go together with a PR that changes the UmbracoDocs branch used to fetch our.
The new branch that should be used is: https://github.com/umbraco/UmbracoDocs/tree/legacy-docs 

This PR will make Umbraco 8 the new main version in the Documentation section on Our.

This PR will remove version 9 and 10 from the docs search.
It also removes `(current)` from the versioning box, as it does not make sense to say that Umbraco 8 is current.

The following AppSetting key in the Umbraco.Site web.config needs to be updated:
`<add key="Documentation:CurrentMajorVersion" value="10"/>`
The value needs to be changed from `10` to `8`.
(I couldn't do that through the PR for some reason - looks like the file is added to the `.gitignore`)

More work might need to be done to ensure that Our "forgets" all about 9 and 10.
