### PR TITLE
Add .NET 6 & 7 to packge .NET version options

### DIFF
--- a/OurUmbraco.Site/Views/Partials/Project/EditFiles.cshtml
+++ b/OurUmbraco.Site/Views/Partials/Project/EditFiles.cshtml
@@ -128,6 +128,8 @@
                                 <option value="4.7.1">4.7.1</option>
                                 <option value="4.7.2">4.7.2</option>
                                 <option value="5.0.0">5.0.0</option>
+                                <option value="6.0.0">6.0.0</option>
+                                <option value="7.0.0">7.0.0</option>
                             </select><br>
                         </p>
 


### PR DESCRIPTION
_Yes yes, I know we're supposed to be using the awesome new Marketplace now..._

I came back into Our for the first time in ages to update an old package. I noticed that it's possible to mark your package as supporting Umbraco 9, 10, 11, 12... but only possible to mark your package as supporting .NET 5, rather than .NET 6 or .NET 7 as required for Umbraco 10/11 respectively.