### PR TITLE
Add MCB blog

### DIFF
--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -359,6 +359,15 @@
       "rss": "https://www.andybutland.dev/feeds/posts/default?alt=rss",
       "logo": "https://avatars.githubusercontent.com/u/1993459",
       "memberId": 6683
-    }	  
+    },
+    {
+      "id": "fc7ded60-4494-441f-8916-3185d0571157",
+      "checkTitles": false,
+      "title": "MCB Blog",
+      "url": "https://blog.mcb.dk/tag/umbraco",
+      "rss": "https://blog.mcb.dk/en/tag/umbraco/rss.xml",
+      "logo": "https://avatars.githubusercontent.com/u/7870099?s=2568",
+      "memberId": null
+    }
   ]
 }

--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -364,7 +364,7 @@
       "id": "fc7ded60-4494-441f-8916-3185d0571157",
       "checkTitles": false,
       "title": "MCB Blog",
-      "url": "https://blog.mcb.dk/tag/umbraco",
+      "url": "https://blog.mcb.dk/en/tag/umbraco",
       "rss": "https://blog.mcb.dk/en/tag/umbraco/rss.xml",
       "logo": "https://avatars.githubusercontent.com/u/7870099?s=2568",
       "memberId": null

--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -366,7 +366,7 @@
       "title": "MCB Blog",
       "url": "https://blog.mcb.dk/en/tag/umbraco",
       "rss": "https://blog.mcb.dk/en/tag/umbraco/rss.xml",
-      "logo": "https://avatars.githubusercontent.com/u/7870099?s=2568",
+      "logo": "https://avatars.githubusercontent.com/u/7870099?s=256",
       "memberId": null
     }
   ]


### PR DESCRIPTION
Adding our blog at MCB where we once in a while blog about Umbraco related topics.
https://blog.mcb.dk/en/tag/umbraco

Not sure if the id is just a random generated guid?

I noticed the id referring the blog from @glombek is without hyphen and the logo/avatar is the following:
https://2.gravatar.com/avatar/6e03aef14c3e69d4e14b111b10d480a70ecc5a60a7dd5975472a68c06f5b48e8?size=256

but the same version here - maybe preferable.
https://gravatar.com/avatar/6e03aef14c3e69d4e14b111b10d480a70ecc5a60a7dd5975472a68c06f5b48e8?size=256