### PR TITLE
Fix broken logo

### DIFF
--- a/OurUmbraco.Site/config/CommunityBlogs.json
+++ b/OurUmbraco.Site/config/CommunityBlogs.json
@@ -285,7 +285,7 @@
       "title": "Michaels uGarage",
       "url": "https://michaels-ugarage.cyber-solutions.at",
       "rss": "https://michaels-ugarage.cyber-solutions.at/rss",
-      "logo": "https://michaels-ugarage.cyber-solutions.at/img/logos/logo.png",
+      "logo": "https://michaels-ugarage.cyber-solutions.at/media/v4lbwrd2/logo.png",
       "memberId": 286196
     },
     {


### PR DESCRIPTION
I noticed a broken logo/avatar here:
https://community.umbraco.com/learn-about-the-community/blog-posts/?page=5

![image](https://github.com/umbraco/OurUmbraco/assets/2919859/9cc2234f-ee39-4a7e-8fca-c2437afd8f83)

which point on https://our.umbraco.com/media/blogs/574d8335-d429-4ff7-8877-dcd863206eae.png

According to the JSON file it should use this logo though, which doesn't exist either.
https://michaels-ugarage.cyber-solutions.at/media/v4lbwrd2/logo.png

I updated to https://michaels-ugarage.cyber-solutions.at/media/v4lbwrd2/logo.png

Maybe @ReiterM2000 can confirm it should use this as logo instead?