### PR TITLE
Remove version number from footer

### DIFF
--- a/OurUmbraco.Site/Views/Master.cshtml
+++ b/OurUmbraco.Site/Views/Master.cshtml
@@ -163,11 +163,6 @@
                     {
                         <text>This site is running Umbraco.</text>
                     }
-                    else
-                    {
-                        <text>This site is running</text>
-                        <data id="umbraco-version" value="@UmbracoVersion.GetSemanticVersion()">Umbraco version @UmbracoVersion.GetSemanticVersion()</data>
-                    }
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Maybe I am being overly critical, but I think it's a good idea to remove the version number from the footer, especially since Umbraco 7 is end of life.