### PR TITLE
Limit version number reported in upgrade check to 3 parts

### DIFF
--- a/OurUmbraco/Our/Api/UpgradeCheckController.cs
+++ b/OurUmbraco/Our/Api/UpgradeCheckController.cs
@@ -66,7 +66,7 @@ namespace OurUmbraco.Our.Api
             if (version.Major == 7 || version.Major == 8 || version.Major > 8)
             {
                 if (version < latestVersion)
-                    return Json(new UpgradeResult(UpgradeType.Minor, $"{latestVersion} is released. Upgrade today - it's free!", $"http://our.umbraco.org/contribute/releases/{latestVersion.Major}{latestVersion.Minor}{latestVersion.Build}"));
+                    return Json(new UpgradeResult(UpgradeType.Minor, $"{latestVersion.ToString(3)} is released. Upgrade today - it's free!", $"http://our.umbraco.org/contribute/releases/{latestVersion.Major}{latestVersion.Minor}{latestVersion.Build}"));
             }
 
             // If nothing matches then it's probably a nightly or a very old version, no need to send upgrade message


### PR DESCRIPTION
There was a [query raised on the CMS tracker](https://github.com/umbraco/Umbraco-CMS/issues/17910) around what the 4th part of the version number reported on an upgrade check meant.

Give we only release for upgrades versions with major.minor.patch - the fourth revision part is always 0 and hence superfluous, so we could remove it to avoid confusion.

I've done this in this PR for V7 and above (seems like back in time we did use the revision part, but we haven't for many years).

Confession time... I tried and failed to get our.umbraco.com running locally 🙈, so I haven't tested this in situ (only in some throwaway code).  So it does need checking before deploying even if it looks correct.